### PR TITLE
fix: add structured output support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Breaking Changes
+* `ResilientLLM.chat()` now always returns a consistent envelope object: `{ content, toolCalls?, metadata }` (metadata is no longer gated by `returnOperationMetadata`).
+
 ## [1.7.1](https://github.com/gitcommitshow/resilient-llm/compare/v1.7.0...v1.7.1) (2026-03-16)
 
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ const conversationHistory = [
 
 (async () => {
   try {
-    const response = await llm.chat(conversationHistory);
-    console.log('LLM response:', response);
+    const { content, toolCalls, metadata } = await llm.chat(conversationHistory);
+    console.log('LLM response:', content);
   } catch (err) {
     console.error('Error:', err);
   }
@@ -91,6 +91,37 @@ import { ProviderRegistry } from 'resilient-llm';
 - **`ProviderRegistry.hasApiKey(providerName)`** - Check if an API key is configured for a provider
 
 See the [full API reference](./docs/reference.md) for complete documentation.
+
+## Structured output (JSON + schema)
+
+Use `llm.chat(..., { responseFormat })` when you need the assistant to return **machine-readable JSON**, optionally matching a **specific JSON Schema**.
+
+```javascript
+// JSON mode (single JSON object)
+const { content: obj } = await llm.chat(messages, { responseFormat: { type: 'json_object' } });
+
+// Schema mode (validate required keys/types)
+const { content: result } = await llm.chat(messages, {
+  responseFormat: {
+    type: 'json_schema',
+    json_schema: {
+      name: 'answer_payload',
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { answer: { type: 'string' } },
+        required: ['answer']
+      }
+    }
+  }
+});
+
+// `result` is a parsed JS object (not a string).
+// If the model returns invalid JSON or fails schema validation,
+// `llm.chat(...)` throws a StructuredOutputError with `code` and `validation` details.
+```
+
+For all supported shapes (including plain schema objects) and parsing/validation behavior, see [`responseFormat` docs](./docs/reference.md#responseformat-json-mode--schema-mode).
 
 ## Supported LLM Providers
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -124,8 +124,17 @@ chat(conversationHistory: Message[], llmOptions?: ChatOptions): Promise<string |
 | `reasoningEffort` | `string` | Reasoning effort level: `"low"`, `"medium"`, or `"high"` (for reasoning models) |
 | `apiKey` | `string` | Override API key for this request (takes precedence over ProviderRegistry) |
 | `tools` | `Tool[]` | Array of tool definitions for function calling |
-| `responseFormat` | `Object` | Response format specification (e.g., `{ type: "json_object" }`) |
+| `responseFormat` | `Object \| string` | Response format specification (`json_object`/`json_schema` object shapes, plain schema-like object, or JSON aliases: `"json"`, `"object"`, `"json_object"`) |
+| `response_format` | `Object \| string` | Snake_case alias for `responseFormat`; passthrough-friendly when using provider-native payload naming |
+| `outputConfig` | `Object` | Alternate structured-output input shape (Anthropic-style), normalized internally with `responseFormat` |
+| `output_config` | `Object` | Snake_case alias for `outputConfig`; passed through as-is when provided |
+| `parseStructuredOutput` | `boolean` | Defaults to `true`. When `false`, returns raw model content even in JSON/schema modes so callers can parse in a second step |
 | `returnOperationMetadata` | `boolean` | When `true`, this request returns a [ChatResponse](#chatresponse) with `metadata`; overrides the constructor default for this call only |
+
+Use one naming style per field to avoid ambiguity:
+- Prefer camelCase (`responseFormat`, `outputConfig`) in app code.
+- Prefer snake_case (`response_format`, `output_config`) when reusing raw provider payload snippets.
+- Do not send both aliases for the same field in one request; the library now throws a clear error.
 
 **Tool:**
 
@@ -138,18 +147,17 @@ chat(conversationHistory: Message[], llmOptions?: ChatOptions): Promise<string |
 | `function.parameters` | `Object` | Function parameters schema (OpenAI format) |
 | `function.input_schema` | `Object` | Function input schema (Anthropic format) |
 
-**Returns:** `Promise<string | ChatResponse>`
+**Returns:** `Promise<string | Object | ChatResponse>`
 
-- If `tools` are provided, returns `ChatResponse` with `content` and `toolCalls`; otherwise returns a `string` (the assistant's reply).
+- If `tools` are provided, returns `ChatResponse` with `content` and `toolCalls`; otherwise returns a `string` or normalized JSON object (when JSON response mode is requested).
 - If `returnOperationMetadata` is set to `true` (constructor or `llmOptions`): Returns a `ChatResponse` with `content` and `metadata` ([OperationMetadata](#operationmetadata))
-- Otherwise: Returns `string` containing 
-the assistant's response.
+- Otherwise: Returns `string` or normalized JSON object containing the assistant response (unless `parseStructuredOutput: false`, which returns raw content).
 
 **ChatResponse:**
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `content` | `string \| null` | The text content of the response |
+| `content` | `string \| Object \| null` | The assistant content (text by default, normalized JSON object in JSON modes) |
 | `toolCalls` | `Array` | Array of tool call objects (if tools were used) |
 | `metadata` | `OperationMetadata` | Present when `returnOperationMetadata` is `true` (request id, config, timing, retries, rate limiting, usage, etc.) |
 
@@ -159,12 +167,16 @@ the assistant's response.
 - `Error` - If API key is not set for the selected service (unless auth is optional)
 - `Error` - If the AI service/provider is invalid
 - `Error` - If API request fails
+- `Error` - If JSON mode parsing fails (`code: "JSON_PARSE_ERROR"`, `rawResponse`)
+- `Error` - If JSON response is not an object (`code: "JSON_MODE_FAILURE"`, `rawResponse`)
+- `Error` - If schema validation fails (`code: "SCHEMA_MISMATCH"`, `rawResponse`, `validation: SchemaValidationIssue`)
 
 **Notes:**
 
 - API keys can be provided via `llmOptions.apiKey`, `ProviderRegistry.configure()`, or environment variables
 - The implementation uses `ProviderRegistry` to manage providers and their configurations
 - Response parsing is handled generically using provider-specific `chatConfig` settings
+- For schema mode, validation checks top-level required fields and primitive types (`string`, `number`, `boolean`, `integer`). Schema mismatch errors include a `validation` object with `missingFields`, `extraFields`, and `typeMismatches` arrays
 
 **Example:**
 ```javascript
@@ -217,9 +229,9 @@ const llm = new ResilientLLM({
 
 const { content, metadata } = await llm.chat(conversationHistory);
 console.log(content);           // Assistant reply text
-console.log(metadata.requestId);
-console.log(metadata.timing.totalTimeMs);
-console.log(metadata.usage);    // prompt_tokens, completion_tokens, total_tokens
+console.log(metadata?.requestId);
+console.log(metadata?.timing?.totalTimeMs);
+console.log(metadata?.usage);    // prompt_tokens, completion_tokens, total_tokens
 ```
 
 ---
@@ -615,8 +627,51 @@ interface ChatOptions {
   apiKey?: string;
   tools?: Tool[];
   responseFormat?: Object;
+  outputConfig?: Object;
+  parseStructuredOutput?: boolean;
   returnOperationMetadata?: boolean;
 }
+```
+
+`responseFormat` examples:
+
+```typescript
+// JSON alias strings (equivalent to { type: 'json_object' })
+'json'
+'object'
+'json_object'
+
+// OpenAI-compatible JSON mode
+{ type: 'json_object' }
+
+// OpenAI-compatible structured output
+{
+  type: 'json_schema',
+  json_schema: {
+    name: 'answer_payload',
+    schema: {
+      type: 'object',
+      properties: { answer: { type: 'string' } },
+      required: ['answer']
+    }
+  }
+}
+
+// Plain schema-like object (auto-wrapped to provider-native format when possible)
+{
+  type: 'object',
+  properties: { answer: { type: 'string' } },
+  required: ['answer']
+}
+
+// Hybrid mode: send structured config, parse manually later
+const raw = await llm.chat(messages, {
+  responseFormat: { type: 'json_object' },
+  parseStructuredOutput: false
+});
+
+const parser = StructuredOutput.fromInputs({ responseFormat: { type: 'json_object' } });
+const parsed = parser.parse(raw);
 ```
 
 ### Tool

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -52,7 +52,6 @@ new ResilientLLM(options?: ResilientLLMOptions)
 | `backoffFactor` | `number` | No | `2` | Exponential backoff multiplier between retries |
 | `onRateLimitUpdate` | `Function` | No | `undefined` | Callback function called when rate limit information is updated |
 | `onError` | `Function` | No | `undefined` | Currently not used (reserved for future use) |
-| `returnOperationMetadata` | `boolean` | No | `false` | When `true`, `chat()` returns a [ChatResponse](#chatresponse) with `metadata` populated instead of a plain string (see [OperationMetadata](#operationmetadata)) |
 
 **RateLimitConfig:**
 
@@ -79,12 +78,6 @@ const llm = new ResilientLLM({
 
 ---
 
-### ResilientLLM Static Properties
-
-_No static properties currently available. Use `ProviderRegistry.getDefaultModels()` to get default models for all providers._
-
----
-
 ### ResilientLLM Instance Methods
 
 #### `chat(conversationHistory, llmOptions?)`
@@ -93,7 +86,7 @@ Sends a chat completion request to the configured LLM provider.
 
 **Signature:**
 ```typescript
-chat(conversationHistory: Message[], llmOptions?: ChatOptions): Promise<string | ChatResponse>
+chat(conversationHistory: Message[], llmOptions?: ChatOptions): Promise<ChatResponse>
 ```
 
 **Parameters:**
@@ -125,16 +118,14 @@ chat(conversationHistory: Message[], llmOptions?: ChatOptions): Promise<string |
 | `apiKey` | `string` | Override API key for this request (takes precedence over ProviderRegistry) |
 | `tools` | `Tool[]` | Array of tool definitions for function calling |
 | `responseFormat` | `Object \| string` | Response format specification (`json_object`/`json_schema` object shapes, plain schema-like object, or JSON aliases: `"json"`, `"object"`, `"json_object"`) |
-| `response_format` | `Object \| string` | Snake_case alias for `responseFormat`; passthrough-friendly when using provider-native payload naming |
-| `outputConfig` | `Object` | Alternate structured-output input shape (Anthropic-style), normalized internally with `responseFormat` |
-| `output_config` | `Object` | Snake_case alias for `outputConfig`; passed through as-is when provided |
-| `parseStructuredOutput` | `boolean` | Defaults to `true`. When `false`, returns raw model content even in JSON/schema modes so callers can parse in a second step |
-| `returnOperationMetadata` | `boolean` | When `true`, this request returns a [ChatResponse](#chatresponse) with `metadata`; overrides the constructor default for this call only |
+| `outputConfig` | `Object` | **Legacy/migration support**. Anthropic-style alternative structured-output input shape, normalized internally via `responseFormat`. _Prefer `responseFormat` for all new usage._ |
+| `response_format` | `Object \| string` | **Legacy/migration support**. Snake_case alias for `responseFormat`; passthrough-friendly for provider-native payloads. _Prefer `responseFormat` for all new usage._ |
+| `output_config` | `Object` | **Legacy/migration support**. Snake_case alias for `outputConfig`; passed through as-is when provided. _Prefer `responseFormat` for all new usage._ |
 
 Use one naming style per field to avoid ambiguity:
-- Prefer camelCase (`responseFormat`, `outputConfig`) in app code.
+- Prefer camelCase (`responseFormat` or its alias `outputConfig`) in app code.
 - Prefer snake_case (`response_format`, `output_config`) when reusing raw provider payload snippets.
-- Do not send both aliases for the same field in one request; the library now throws a clear error.
+- Do not send both aliases for the same field in one request; conflicting info may result in error.
 
 **Tool:**
 
@@ -147,11 +138,12 @@ Use one naming style per field to avoid ambiguity:
 | `function.parameters` | `Object` | Function parameters schema (OpenAI format) |
 | `function.input_schema` | `Object` | Function input schema (Anthropic format) |
 
-**Returns:** `Promise<string | Object | ChatResponse>`
+**Returns:** `Promise<ChatResponse>`
 
-- If `tools` are provided, returns `ChatResponse` with `content` and `toolCalls`; otherwise returns a `string` or normalized JSON object (when JSON response mode is requested).
-- If `returnOperationMetadata` is set to `true` (constructor or `llmOptions`): Returns a `ChatResponse` with `content` and `metadata` ([OperationMetadata](#operationmetadata))
-- Otherwise: Returns `string` or normalized JSON object containing the assistant response (unless `parseStructuredOutput: false`, which returns raw content).
+- Always returns a predictable envelope:
+  - `response.content` is the assistant output (string in text mode, parsed object in JSON/schema mode)
+  - `response.toolCalls` is included when tool calls are returned
+- `response.metadata` is always included
 
 **ChatResponse:**
 
@@ -159,7 +151,7 @@ Use one naming style per field to avoid ambiguity:
 |----------|------|-------------|
 | `content` | `string \| Object \| null` | The assistant content (text by default, normalized JSON object in JSON modes) |
 | `toolCalls` | `Array` | Array of tool call objects (if tools were used) |
-| `metadata` | `OperationMetadata` | Present when `returnOperationMetadata` is `true` (request id, config, timing, retries, rate limiting, usage, etc.) |
+| `metadata` | `OperationMetadata` | Always included (request id, config, timing, retries, rate limiting, usage, etc.) |
 
 **Throws:**
 
@@ -185,8 +177,8 @@ const conversationHistory = [
   { role: 'user', content: 'What is the capital of France?' }
 ];
 
-const response = await llm.chat(conversationHistory);
-console.log(response); // "The capital of France is Paris."
+const { content } = await llm.chat(conversationHistory);
+console.log(content); // "The capital of France is Paris."
 ```
 
 **Example with tools:**
@@ -224,7 +216,6 @@ const response = await llm.chat(conversationHistory, {
 const llm = new ResilientLLM({
   aiService: 'openai',
   model: 'gpt-4o-mini',
-  returnOperationMetadata: true
 });
 
 const { content, metadata } = await llm.chat(conversationHistory);
@@ -442,7 +433,7 @@ Retries the chat request with an alternate AI service when the current service r
 
 **Signature:**
 ```typescript
-retryChatWithAlternateService(conversationHistory: Message[], llmOptions?: ChatOptions): Promise<string | ChatResponse>
+retryChatWithAlternateService(conversationHistory: Message[], llmOptions?: ChatOptions): Promise<ChatResponse>
 ```
 
 **Parameters:**
@@ -452,7 +443,7 @@ retryChatWithAlternateService(conversationHistory: Message[], llmOptions?: ChatO
 | `conversationHistory` | `Message[]` | Yes | Array of message objects |
 | `llmOptions` | `ChatOptions` | No | LLM options for the request |
 
-**Returns:** `Promise<string | ChatResponse>` - Response from the alternate service
+**Returns:** `Promise<ChatResponse>` - Response from the alternate service
 
 **Throws:**
 
@@ -519,25 +510,32 @@ interface Message {
 
 ### ChatResponse
 
-Response object returned by `chat()` when tools are used and/or `returnOperationMetadata` is `true`. Otherwise `chat()` returns a plain `string`.
+Response envelope returned by `chat()` on every call.
+
+- `content` is the assistant output:
+  - text mode -> `string`
+  - JSON/schema mode -> parsed JS object
+- `toolCalls` is present when tool calls were returned
+- `metadata` is always included
 
 ```typescript
 interface ChatResponse {
-  content: string | null;
+  content: string | Object | null;
   toolCalls?: Array<any>;
-  metadata?: OperationMetadata;  // present when returnOperationMetadata is true
+  metadata: OperationMetadata;
 }
 ```
 
 ### OperationMetadata
 
-Operation metadata attached to `ChatResponse.metadata` when `returnOperationMetadata` is `true` (constructor or per-call). Used for observability, logging, and debugging.
+Operation metadata attached to `ChatResponse.metadata` on every call. Used for observability, logging, and debugging.
 
 ```typescript
 interface OperationMetadata {
   requestId: string;
   operationId: string;
   startTime: number;
+  finishReason?: string | null;
   config: {
     aiService: string;
     model: string;
@@ -606,7 +604,6 @@ interface ResilientLLMOptions {
   backoffFactor?: number;
   onRateLimitUpdate?: (info: RateLimitInfo) => void;
   onError?: (error: Error) => void;
-  returnOperationMetadata?: boolean;
 }
 ```
 
@@ -628,12 +625,122 @@ interface ChatOptions {
   tools?: Tool[];
   responseFormat?: Object;
   outputConfig?: Object;
-  parseStructuredOutput?: boolean;
-  returnOperationMetadata?: boolean;
 }
 ```
 
-`responseFormat` examples:
+#### `responseFormat` (JSON mode + schema mode)
+
+Use `responseFormat` when you need the assistant response as **JSON**, optionally matching a **particular schema**.
+
+- **JSON mode (no schema)**: ensures the reply is a single JSON object (library parses it for you).
+- **Schema mode**: provides a JSON Schema so the library can validate the parsed object and throw `SCHEMA_MISMATCH` when required keys/types don’t match.
+
+**Supplying a schema**
+
+You can supply a schema in any of these equivalent shapes (pick one and stick to it):
+
+- **OpenAI-style wrapper** (recommended when you want to be explicit):
+
+```typescript
+responseFormat: {
+  type: 'json_schema',
+  json_schema: {
+    name: 'my_payload',
+    schema: {
+      type: 'object',
+      properties: {
+        answer: { type: 'string' },
+        citations: { type: 'array', items: { type: 'string' } }
+      },
+      required: ['answer']
+    }
+  }
+}
+```
+
+- **Short wrapper** (schema directly on the object):
+
+```typescript
+responseFormat: {
+  type: 'json_schema',
+  schema: {
+    type: 'object',
+    properties: { answer: { type: 'string' } },
+    required: ['answer']
+  }
+}
+```
+
+- **Plain schema-like object** (auto-detected as a schema):
+
+```typescript
+responseFormat: {
+  type: 'object',
+  properties: { answer: { type: 'string' } },
+  required: ['answer']
+}
+```
+
+**End-to-end example (schema mode)**
+
+```typescript
+const llm = new ResilientLLM({ aiService: 'openai', model: 'gpt-4o-mini' });
+
+const result = await llm.chat(
+  [{ role: 'user', content: 'Return an answer and citations.' }],
+  {
+    responseFormat: {
+      type: 'json_schema',
+      json_schema: {
+        name: 'answer_payload',
+        schema: {
+          type: 'object',
+          properties: {
+            answer: { type: 'string' },
+            citations: { type: 'array', items: { type: 'string' } }
+          },
+          required: ['answer']
+        }
+      }
+    }
+  }
+);
+
+// `result.content` is a parsed JS object when `responseFormat` requests JSON/schema mode.
+```
+
+**Validation scope (important)**
+
+The built-in validator is intentionally lightweight: it checks **required keys**, **extra keys**, and **primitive types** at the top level (`string`, `number`, `boolean`, `integer`).
+
+- Extra keys are enforced only when your schema sets `additionalProperties: false` (and the schema has `properties`).
+- For deeper validation needs (nested objects, enums, regex, oneOf/anyOf, etc.), run your own schema validator after the call.
+
+**Example: `additionalProperties: false` + `required`**
+
+```typescript
+const result = await llm.chat(messages, {
+  responseFormat: {
+    type: 'json_schema',
+    json_schema: {
+      name: 'answer_payload',
+      schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          answer: { type: 'string' }
+        },
+        required: ['answer']
+      }
+    }
+  }
+});
+
+// `result.content` is { answer: string } when the model output matches the schema.
+// If the model returns invalid JSON or extra keys, `llm.chat(...)` throws StructuredOutputError (e.g. `SCHEMA_MISMATCH`).
+```
+
+#### `responseFormat` examples (quick)
 
 ```typescript
 // JSON alias strings (equivalent to { type: 'json_object' })
@@ -644,34 +751,8 @@ interface ChatOptions {
 // OpenAI-compatible JSON mode
 { type: 'json_object' }
 
-// OpenAI-compatible structured output
-{
-  type: 'json_schema',
-  json_schema: {
-    name: 'answer_payload',
-    schema: {
-      type: 'object',
-      properties: { answer: { type: 'string' } },
-      required: ['answer']
-    }
-  }
-}
-
-// Plain schema-like object (auto-wrapped to provider-native format when possible)
-{
-  type: 'object',
-  properties: { answer: { type: 'string' } },
-  required: ['answer']
-}
-
-// Hybrid mode: send structured config, parse manually later
-const raw = await llm.chat(messages, {
-  responseFormat: { type: 'json_object' },
-  parseStructuredOutput: false
-});
-
-const parser = StructuredOutput.fromInputs({ responseFormat: { type: 'json_object' } });
-const parsed = parser.parse(raw);
+// When `responseFormat` requests JSON, `llm.chat(...)` resolves to a response envelope
+// where `.content` is the parsed JS object.
 ```
 
 ### Tool

--- a/docs/resilience-configuration.md
+++ b/docs/resilience-configuration.md
@@ -25,7 +25,7 @@ ResilientLLM provides multiple layers of resilience to handle common production 
 - **Timeout Control**: Prevents operations from hanging indefinitely
 - **Caching**: Reduces redundant API calls for identical requests
 - **Automatic Fallback**: Switches to alternative providers when rate limits are hit
-- **Operation metadata**: Optional `returnOperationMetadata` returns per-call metadata (timing, retries, rate limiting, usage) for observability and debugging—see [Reference: OperationMetadata](reference.md#operationmetadata)
+- **Operation metadata**: Returned on every call as `response.metadata` (timing, retries, rate limiting, usage) for observability and debugging—see [Reference: OperationMetadata](reference.md#operationmetadata)
 
 All resilience features are configured through the `ResilientLLM` constructor options.
 
@@ -127,7 +127,6 @@ await highRetryLLM.chat(conversationHistory);  // Uses retries: 5
 - ✅ `maxTokens` - Override max tokens for this request
 - ✅ `aiService` - Switch provider for this request
 - ✅ `apiKey` - Override API key for this request
-- ✅ `returnOperationMetadata` - Request `{ content, metadata }` for this call only (overrides instance default)
 
 **What CANNOT be overridden per request:**
 - ❌ `retries` - Use instance's retry count
@@ -151,7 +150,6 @@ await highRetryLLM.chat(conversationHistory);  // Uses retries: 5
 | `temperature` | Per instance (default) | ✅ Yes |
 | `maxTokens` | Per instance (default) | ✅ Yes |
 | `aiService` | Per instance (default) | ✅ Yes |
-| `returnOperationMetadata` | Per instance (default) | ✅ Yes |
 
 ---
 

--- a/examples/chat-basic/README.md
+++ b/examples/chat-basic/README.md
@@ -109,10 +109,15 @@ const llm = new ResilientLLM({
 **2. Use it in your API endpoint:**
 ```javascript
 app.post('/api/chat', async (req, res) => {
-    const { conversationHistory } = req.body;
-    const response = await llm.chat(conversationHistory);
-    res.json({ response, success: true });
-});`
+    const { conversationHistory, llmOptions } = req.body;
+    const { content, toolCalls, metadata } = await llm.chat(conversationHistory, llmOptions || {});
+    res.json({
+        success: true,
+        content,
+        ...(toolCalls !== undefined ? { toolCalls } : {}),
+        metadata
+    });
+});
 ```
 
 **3. Send chat history from the frontend to get the AI response:**

--- a/examples/chat-basic/client/api.js
+++ b/examples/chat-basic/client/api.js
@@ -37,7 +37,7 @@ function buildConversationHistory(messages) {
  * - Error handling and recovery
  * 
  * @param {Array} conversationHistory - Array of messages with role and content
- * @returns {Promise<string>} - The AI response text
+ * @returns {Promise<string>} - Assistant output as text (objects are JSON-stringified)
  */
 async function getAIResponse(conversationHistory) {
     try {
@@ -56,12 +56,19 @@ async function getAIResponse(conversationHistory) {
             throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
         }
 
+        // Server mirrors llm.chat(): { success, content, toolCalls?, metadata }
         const data = await response.json();
-        if (data.success && data.response) {
-            return data.response;
-        } else {
+        if (!data.success) {
             throw new Error(data.error || 'No response from server');
         }
+        const { content } = data;
+        if (typeof content === 'string') {
+            return content;
+        }
+        if (content != null && typeof content === 'object') {
+            return JSON.stringify(content, null, 2);
+        }
+        return content == null ? '' : String(content);
     } catch (error) {
         console.error('Error calling API:', error);
         throw error;

--- a/examples/chat-basic/server/app.js
+++ b/examples/chat-basic/server/app.js
@@ -41,11 +41,14 @@ app.post('/api/chat', async (req, res) => {
             });
         }
 
-        const response = await llm.chat(conversationHistory, llmOptions || {});
-        
-        res.json({ 
-            response,
-            success: true 
+        // llm.chat() always returns { content, toolCalls?, metadata }
+        const { content, toolCalls, metadata } = await llm.chat(conversationHistory, llmOptions || {});
+
+        res.json({
+            success: true,
+            content,
+            ...(toolCalls !== undefined ? { toolCalls } : {}),
+            metadata
         });
     } catch (error) {
         console.error('Error in chat endpoint:', error);

--- a/examples/playground-js/client/REFACTOR_PLAN.md
+++ b/examples/playground-js/client/REFACTOR_PLAN.md
@@ -118,7 +118,7 @@ export class State {
       globalConfig: {        // Shared config (can be overridden per panel)
         service: '',
         model: '',
-        responseMode: 'text'
+        responseFormat: 'text'
       }
     };
   }
@@ -737,7 +737,7 @@ export class MessageRenderer {
   constructor({ 
     container,           // Parent element to render into
     message,             // Message object
-    responseMode,        // 'text' | 'json'
+    responseFormat,        // 'text' | 'json'
     onEdit,              // (messageId, newText) => void
     onDelete,            // (messageId) => void
     onBranch,            // (messageId) => void

--- a/examples/playground-js/client/api.js
+++ b/examples/playground-js/client/api.js
@@ -28,7 +28,7 @@ export function buildConversationHistory(messages) {
  * 
  * @param {Array} conversationHistory - Array of messages with role and content
  * @param {Object} llmOptions - Optional LLM configuration options
- * @returns {Promise<string>} - The AI response text
+ * @returns {Promise<string>} - Assistant output as text (objects are JSON-stringified)
  */
 export async function getAIResponse(conversationHistory, llmOptions = {}) {
     try {
@@ -48,12 +48,19 @@ export async function getAIResponse(conversationHistory, llmOptions = {}) {
             throw new Error(errorData.error || `HTTP error! status: ${response.status}`);
         }
 
+        // Server mirrors llm.chat(): { success, content, toolCalls?, metadata }
         const data = await response.json();
-        if (data.success && data.response) {
-            return data.response;
-        } else {
+        if (!data.success) {
             throw new Error(data.error || 'No response from server');
         }
+        const { content } = data;
+        if (typeof content === 'string') {
+            return content;
+        }
+        if (content != null && typeof content === 'object') {
+            return JSON.stringify(content, null, 2);
+        }
+        return content == null ? '' : String(content);
     } catch (error) {
         console.error('Error calling API:', error);
         throw error;

--- a/examples/playground-js/server/app.js
+++ b/examples/playground-js/server/app.js
@@ -42,11 +42,14 @@ app.post('/api/chat', async (req, res) => {
         }
 
         // Pass llmOptions through; ResilientLLM.chat will use llmOptions.apiKey (if provided)
-        const response = await llm.chat(conversationHistory, llmOptions || {});
-        
-        res.json({ 
-            response,
-            success: true 
+        // llm.chat() always returns { content, toolCalls?, metadata }
+        const { content, toolCalls, metadata } = await llm.chat(conversationHistory, llmOptions || {});
+
+        res.json({
+            success: true,
+            content,
+            ...(toolCalls !== undefined ? { toolCalls } : {}),
+            metadata
         });
     } catch (error) {
         console.error('Error in chat endpoint:', error);

--- a/examples/playground-nextjs/src/app/api/chat/route.ts
+++ b/examples/playground-nextjs/src/app/api/chat/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ResilientLLM } from 'resilient-llm';
 
+/** Mirrors `llm.chat()` return shape so this route stays typed even if linked package typings lag. */
+interface LlmChatEnvelope {
+  content: string | Record<string, unknown> | null;
+  toolCalls?: unknown;
+  metadata: Record<string, unknown>;
+}
+
 // Store LLM instances per service for reuse
 const llmInstances: Record<string, ResilientLLM> = {};
 
@@ -130,14 +137,15 @@ export async function POST(request: NextRequest) {
       timestamp: Date.now() - startTime
     });
 
-    // Make the chat request; ResilientLLM.chat will use apiKey (if provided)
-    const response = await llm.chat(messages, {
+    // llm.chat() always returns { content, toolCalls?, metadata }
+    const chatResult = (await llm.chat(messages, {
       aiService,
       model: selectedModel,
       maxTokens,
       temperature,
       apiKey
-    });
+    })) as LlmChatEnvelope;
+    const { content, toolCalls, metadata } = chatResult;
 
     const totalTime = Date.now() - startTime;
 
@@ -148,7 +156,10 @@ export async function POST(request: NextRequest) {
     });
 
     return NextResponse.json({
-      response,
+      success: true,
+      content,
+      ...(toolCalls !== undefined ? { toolCalls } : {}),
+      metadata,
       resilienceLog,
       metrics: {
         totalTime,

--- a/examples/playground-nextjs/src/app/page.tsx
+++ b/examples/playground-nextjs/src/app/page.tsx
@@ -84,9 +84,19 @@ export default function Playground() {
           },
         ]);
       } else {
+        // API returns the same fields as llm.chat(); normalize non-string content for the message list
+        const raw = data.content;
+        const assistantText =
+          typeof raw === 'string'
+            ? raw
+            : raw != null && typeof raw === 'object'
+              ? JSON.stringify(raw, null, 2)
+              : raw == null
+                ? ''
+                : String(raw);
         setMessages([
           ...newMessages,
-          { role: 'assistant', content: data.response },
+          { role: 'assistant', content: assistantText },
         ]);
       }
     } catch (error) {

--- a/examples/playground-react/client/components/Header.jsx
+++ b/examples/playground-react/client/components/Header.jsx
@@ -7,12 +7,12 @@ import { FaCode, FaChevronRight, FaShieldAlt, FaBrain, FaClock, FaMoon, FaSun } 
 import { getProviderDisplayName } from '../utils/providerUtils';
 
 export function StatusBar() {
-    const { config, configSaved, setSettingsOpen, setSettingsDefaultSection } = useApp();
+    const { config, configSavedModels, setSettingsOpen, setSettingsDefaultSection } = useApp();
     const statusBarRef = useRef(null);
     const serviceName = getProviderDisplayName(config.service) || '—';
     
     useEffect(() => {
-        if (configSaved && statusBarRef.current) {
+        if (configSavedModels && statusBarRef.current) {
             statusBarRef.current.classList.add('saved');
             const timer = setTimeout(() => {
                 if (statusBarRef.current) {
@@ -21,7 +21,7 @@ export function StatusBar() {
             }, 1200);
             return () => clearTimeout(timer);
         }
-    }, [configSaved]);
+    }, [configSavedModels]);
     
     const handleClick = () => {
         setSettingsDefaultSection('models');
@@ -59,11 +59,11 @@ export function StatusBar() {
 }
 
 export function ResilienceStatusBar() {
-    const { config, configSaved, setSettingsOpen, setSettingsDefaultSection } = useApp();
+    const { config, configSavedResilience, setSettingsOpen, setSettingsDefaultSection } = useApp();
     const statusBarRef = useRef(null);
     
     useEffect(() => {
-        if (configSaved && statusBarRef.current) {
+        if (configSavedResilience && statusBarRef.current) {
             statusBarRef.current.classList.add('saved');
             const timer = setTimeout(() => {
                 if (statusBarRef.current) {
@@ -72,7 +72,7 @@ export function ResilienceStatusBar() {
             }, 1200);
             return () => clearTimeout(timer);
         }
-    }, [configSaved]);
+    }, [configSavedResilience]);
     
     const retries = config.retries || '3';
     const timeout = config.timeout || '60000';

--- a/examples/playground-react/client/components/Message.jsx
+++ b/examples/playground-react/client/components/Message.jsx
@@ -87,7 +87,7 @@ export function Message({ message, responseFormat }) {
     return (
         <div className={`message ${message.role} ${isEditing ? 'editing' : ''}`}>
             <div className="message-avatar">{message.role === 'user' ? 'U' : 'AI'}</div>
-            <div className={`message-content ${isEditing ? 'message-content-editing' : ''}`}>
+            <div className={`message-content ${isEditing ? 'message-content-editing' : ''} ${isJson ? 'message-content-json' : ''}`}>
                 {isEditing ? (
                     <textarea
                         ref={textareaRef}

--- a/examples/playground-react/client/context/AppContext.jsx
+++ b/examples/playground-react/client/context/AppContext.jsx
@@ -6,6 +6,51 @@ import { AppContext } from './context';
 import { Storage, generateId, API_URL, getApiKey, THEME_STORAGE_KEY } from '../utils';
 
 /**
+ * Determines which config sections changed between two config objects.
+ */
+function getConfigChangeSections(prevConfig, nextConfig) {
+    const MODEL_KEYS = ['service', 'model', 'temperature', 'maxTokens', 'topP', 'responseFormat'];
+    const RESILIENCE_KEYS = [
+        'retries',
+        'backoffFactor',
+        'timeout',
+        'requestsPerMinute',
+        'llmTokensPerMinute',
+        'circuitBreakerFailureThreshold',
+        'circuitBreakerCooldownPeriod',
+        'maxConcurrent',
+        'enableCache'
+    ];
+
+    const changed = (key) => {
+        const a = prevConfig?.[key];
+        const b = nextConfig?.[key];
+        return JSON.stringify(a) !== JSON.stringify(b);
+    };
+
+    return {
+        modelsChanged: MODEL_KEYS.some(changed),
+        resilienceChanged: RESILIENCE_KEYS.some(changed)
+    };
+}
+
+/**
+ * Maps API `content` (same shape as `llm.chat().content`) to a single string for the message bubble.
+ */
+function formatAssistantContentForDisplay(content) {
+    if (content == null) return '';
+    if (typeof content === 'string') return content;
+    if (typeof content === 'object') {
+        try {
+            return JSON.stringify(content, null, 2);
+        } catch {
+            return String(content);
+        }
+    }
+    return String(content);
+}
+
+/**
  * App Provider - wraps the application with global state
  */
 export function AppProvider({ children }) {
@@ -33,7 +78,8 @@ export function AppProvider({ children }) {
     const [senderRole, setSenderRole] = useState('user');
     const [editingMessageId, setEditingMessageId] = useState(null);
     const [undoNotification, setUndoNotification] = useState(null);
-    const [configSaved, setConfigSaved] = useState(false);
+    const [configSavedModels, setConfigSavedModels] = useState(false);
+    const [configSavedResilience, setConfigSavedResilience] = useState(false);
     const [currentRoute, setCurrentRoute] = useState('playground'); // 'playground' or 'token-bucket'
     const [selectedActivityMessageId, setSelectedActivityMessageId] = useState(null);
     const [isBackendPanelOpen, setIsBackendPanelOpen] = useState(false);
@@ -158,9 +204,16 @@ export function AppProvider({ children }) {
             
             // Trigger pulse if config changed
             if (configChanged) {
+                const { modelsChanged, resilienceChanged } = getConfigChangeSections(previousConfigRef.current, config);
                 previousConfigRef.current = { ...config };
-                setConfigSaved(true);
-                setTimeout(() => setConfigSaved(false), 100);
+                if (modelsChanged) {
+                    setConfigSavedModels(true);
+                    setTimeout(() => setConfigSavedModels(false), 100);
+                }
+                if (resilienceChanged) {
+                    setConfigSavedResilience(true);
+                    setTimeout(() => setConfigSavedResilience(false), 100);
+                }
             }
         }
     }, [activeConversationId, messages, config]);
@@ -402,8 +455,6 @@ export function AppProvider({ children }) {
                 } : {}),
                 ...(config.maxConcurrent && config.maxConcurrent.trim() && { maxConcurrent: parseInt(config.maxConcurrent, 1) }),
                 enableCache: config.enableCache !== false,
-                // Explicitly request operation metadata so the playground can visualize it
-                returnOperationMetadata: true
             };
             
             const response = await fetch(API_URL, {
@@ -414,8 +465,7 @@ export function AppProvider({ children }) {
             const data = await response.json();
             
             if (data.success) {
-                const content = data.response ?? '';
-                const text = typeof content === 'object' && content !== null && 'content' in content ? content.content : content;
+                const text = formatAssistantContentForDisplay(data.content);
                 const meta = data.metadata ? { operation: data.metadata } : undefined;
                 const assistantMsg = addMessage(text, 'assistant', meta);
                 if (assistantMsg && meta && meta.operation) {
@@ -480,8 +530,6 @@ export function AppProvider({ children }) {
                 ...(config.maxConcurrent && config.maxConcurrent.trim() && { maxConcurrent: parseInt(config.maxConcurrent, 1) }),
                 // Regenerate always bypasses cache for this single request
                 enableCache: false,
-                // Explicitly request operation metadata for regenerations too
-                returnOperationMetadata: true
             };
             
             const response = await fetch(API_URL, {
@@ -502,8 +550,7 @@ export function AppProvider({ children }) {
             }
             
             if (data.success) {
-                const content = data.response ?? '';
-                const text = typeof content === 'object' && content !== null && 'content' in content ? content.content : content;
+                const text = formatAssistantContentForDisplay(data.content);
                 const updated = latestMessages.map(m =>
                     m.id === messageId
                         ? {
@@ -780,7 +827,7 @@ export function AppProvider({ children }) {
         // State
         prompts, currentPromptId, currentPrompt, activeConversationId,
         messages, config, isResponding, settingsOpen, settingsDefaultSection, senderRole,
-        editingMessageId, undoNotification, configSaved, currentRoute,
+        editingMessageId, undoNotification, configSavedModels, configSavedResilience, currentRoute,
         selectedActivityMessageId, isBackendPanelOpen,
         // Setters
         setConfig, setSettingsOpen, setSettingsDefaultSection, setSenderRole, setEditingMessageId, setCurrentRoute,

--- a/examples/playground-react/client/styles.css
+++ b/examples/playground-react/client/styles.css
@@ -17,6 +17,8 @@
     --border: #e4e4e7;
     --shadow: rgba(15, 23, 42, 0.06);
     --shadow-strong: rgba(15, 23, 42, 0.12);
+    --status-saved-bg: #e4e4e7;
+    --status-saved-fg: #111827;
 }
 
 [data-theme="dark"] {
@@ -33,6 +35,9 @@
     --scrollbar-thumb-hover: #57534e;
     --shadow: rgba(0, 0, 0, 0.35);
     --shadow-strong: rgba(0, 0, 0, 0.48);
+    /* Saved highlight for status bars should stay readable */
+    --status-saved-bg: rgba(245, 245, 244, 0.12);
+    --status-saved-fg: var(--text-primary);
 }
 
 /* Ensure all react-icons use black/white only - inherit text color */
@@ -140,16 +145,22 @@ body {
 }
 
 .status-bar.saved {
-    background-color: #e4e4e7;
+    background-color: var(--status-saved-bg);
+    color: var(--status-saved-fg);
     animation: statusBarPulse 1.2s ease-out;
+}
+
+.status-bar.saved .status-label,
+.status-bar.saved .status-bar-expand-icon {
+    color: inherit;
 }
 
 @keyframes statusBarPulse {
     0% {
-        background-color: #e4e4e7;
+        background-color: var(--status-saved-bg);
     }
     100% {
-        background-color: #f4f4f5;
+        background-color: var(--bg-muted);
     }
 }
 
@@ -1526,6 +1537,10 @@ body {
 .json-message-container {
     font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
     font-size: 12px;
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-width: 0;
 }
 
 .json-message-toolbar {
@@ -1536,13 +1551,38 @@ body {
     color: #6b7280;
 }
 
+.message-content.message-content-json {
+    max-width: 85%;
+}
+
 .json-message-body {
     background: rgba(0, 0, 0, 0.05);
     border-radius: 6px;
     padding: 8px 10px;
-    max-height: 260px;
+    max-height: 420px;
     overflow: auto;
     white-space: pre;
+    min-width: 0;
+    scrollbar-width: thin;
+    scrollbar-color: #d4d4d8 #f4f4f5;
+}
+
+.json-message-body::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+}
+
+.json-message-body::-webkit-scrollbar-track {
+    background: #f4f4f5;
+}
+
+.json-message-body::-webkit-scrollbar-thumb {
+    background: #d4d4d8;
+    border-radius: 3px;
+}
+
+.json-message-body::-webkit-scrollbar-thumb:hover {
+    background: #a1a1aa;
 }
 
 .json-message-error {
@@ -1948,14 +1988,14 @@ body {
 .backend-activity-tokens-total {
     font-size: 20px;
     font-weight: 600;
-    color: #111827;
+    color: var(--text-primary);
     letter-spacing: -0.02em;
     line-height: 1.2;
 }
 
 .backend-activity-tokens-breakdown {
     font-size: 11px;
-    color: #6b7280;
+    color: var(--text-secondary);
     font-weight: 400;
 }
 
@@ -3353,8 +3393,9 @@ body {
 }
 
 [data-theme="dark"] .message.assistant .message-content {
-    background: var(--bg-panel);
-    box-shadow: 0 1px 3px var(--shadow);
+    /* Blend AI messages into the chat background in dark mode */
+    background: transparent;
+    box-shadow: none;
     color: var(--text-primary);
 }
 
@@ -3397,7 +3438,7 @@ body {
 
 [data-theme="dark"] .typing-indicator-bubble {
     background: var(--bg-panel);
-    border: 1px solid var(--border);
+    border: none;
 }
 
 [data-theme="dark"] .empty-state,
@@ -3441,6 +3482,24 @@ body {
 }
 
 [data-theme="dark"] .message-edit-textarea::-webkit-scrollbar-thumb:hover {
+    background: var(--scrollbar-thumb-hover);
+}
+
+[data-theme="dark"] .json-message-body {
+    background: rgba(255, 255, 255, 0.06);
+    scrollbar-color: var(--border) var(--bg-page);
+}
+
+[data-theme="dark"] .json-message-body::-webkit-scrollbar-track {
+    background: var(--bg-page);
+}
+
+[data-theme="dark"] .json-message-body::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 3px;
+}
+
+[data-theme="dark"] .json-message-body::-webkit-scrollbar-thumb:hover {
     background: var(--scrollbar-thumb-hover);
 }
 
@@ -3587,6 +3646,30 @@ body {
 
 [data-theme="dark"] .system-prompt-input-field:focus {
     box-shadow: 0 0 0 2px rgba(212, 212, 212, 0.15), 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dark"] .system-prompt-pinned-display {
+    color: var(--text-primary);
+}
+
+[data-theme="dark"] .system-prompt-pinned-label {
+    color: var(--text-secondary);
+}
+
+[data-theme="dark"] .system-prompt-preview {
+    color: var(--text-secondary);
+}
+
+[data-theme="dark"] .system-prompt-pinned-toggle {
+    color: var(--text-secondary);
+}
+
+[data-theme="dark"] .system-prompt-pinned-display code {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme="dark"] .system-prompt-pinned-display pre {
+    background: rgba(255, 255, 255, 0.08);
 }
 
 [data-theme="dark"] .prompt-item {

--- a/examples/playground-react/server/app.js
+++ b/examples/playground-react/server/app.js
@@ -27,8 +27,7 @@ const llm = new ResilientLLM({
         llmTokensPerMinute: parseInt(process.env.LLM_TOKENS_PER_MINUTE || '90000')
     },
     retries: parseInt(process.env.RETRIES || '3'),
-    backoffFactor: parseFloat(process.env.BACKOFF_FACTOR || '2'),
-    returnOperationMetadata: true
+    backoffFactor: parseFloat(process.env.BACKOFF_FACTOR || '2')
 });
 
 // Chat endpoint
@@ -43,19 +42,17 @@ app.post('/api/chat', async (req, res) => {
         }
 
         // Pass llmOptions through; ResilientLLM.chat will use llmOptions.apiKey (if provided)
-        const response = await llm.chat(conversationHistory, llmOptions || {});
-        const responseContent = (response && typeof response === 'object' && 'content' in response)
-            ? response.content
-            : response;
-        const metadata = (response && typeof response === 'object' && 'metadata' in response) ? response.metadata : null;
+        // llm.chat() always returns { content, toolCalls?, metadata }
+        const { content, toolCalls, metadata } = await llm.chat(conversationHistory, llmOptions || {});
         if (metadata && !metadata.usage) {
             console.warn('[playground] Operation metadata missing usage; ensure server uses local resilient-llm (npm run playground from repo root).');
         }
 
         res.json({
-            response: responseContent,
             success: true,
-            ...(metadata && { metadata })
+            content,
+            ...(toolCalls !== undefined ? { toolCalls } : {}),
+            metadata
         });
     } catch (error) {
         console.error('Error in chat endpoint:', error);

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,11 @@
 import ResilientLLM from "./lib/ResilientLLM.js";
 import ProviderRegistry from "./lib/ProviderRegistry.js";
+import { StructuredOutput } from "./lib/StructuredOutput.js";
 
 export {
     ResilientLLM,
-    ProviderRegistry
+    ProviderRegistry,
+    StructuredOutput,
 };
 
 export type {
@@ -15,7 +17,15 @@ export type {
     OperationMetadata,
     ChatResponseWithMetadata,
     ChatToolCallResult,
+    SchemaValidationIssue,
 } from "./lib/ResilientLLM.js";
+
+export type {
+    StructuredOutputConfig,
+    StructuredOutputOptions as StructuredOutputInputs,
+    StructuredRequestFields,
+    StructuredContent,
+} from "./lib/StructuredOutput.js";
 
 export type {
     AuthConfig,

--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,13 @@
 import ResilientLLM from "./lib/ResilientLLM.js";
 import ProviderRegistry from "./lib/ProviderRegistry.js";
-import { StructuredOutput } from "./lib/StructuredOutput.js";
+import {
+    StructuredOutputError,
+} from "./lib/StructuredOutput.js";
 
 export {
     ResilientLLM,
     ProviderRegistry,
-    StructuredOutput,
+    StructuredOutputError
 };
 
 export type {
@@ -18,12 +20,18 @@ export type {
     ChatResponseWithMetadata,
     ChatToolCallResult,
     SchemaValidationIssue,
+    StructuredOutputErrorInfo,
 } from "./lib/ResilientLLM.js";
 
 export type {
-    StructuredOutputConfig,
-    StructuredOutputOptions as StructuredOutputInputs,
+    ParseMode,
+    ValidationMode,
+    StructuredOutputResult,
+    StructuredOutputErrorCode,
+    StructuredOutputErrorInfo as StructuredOutputErrorDetail,
+    NormalizedStructuredOutputConfig,
     StructuredRequestFields,
+    ResponseEnvelope,
     StructuredContent,
 } from "./lib/StructuredOutput.js";
 

--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@ export type {
     ToolDefinition,
     ObservabilityOptions,
     OperationMetadata,
-    ChatResponseWithMetadata,
+    ChatResponse,
     ChatToolCallResult,
     SchemaValidationIssue,
     StructuredOutputErrorInfo,

--- a/lib/ProviderRegistry.ts
+++ b/lib/ProviderRegistry.ts
@@ -25,6 +25,7 @@ export interface ChatConfig {
     messageFormat: 'openai' | 'anthropic';
     responseParsePath: string;
     toolSchemaType: 'openai' | 'anthropic';
+    structuredOutputRequestField?: 'response_format' | 'output_config';
 }
 
 export interface ProviderConfig {
@@ -120,6 +121,7 @@ class ProviderRegistry {
                 messageFormat: 'openai',
                 responseParsePath: 'choices[0].message.content',
                 toolSchemaType: 'openai',
+                structuredOutputRequestField: 'response_format',
             },
             active: true
         },
@@ -153,6 +155,7 @@ class ProviderRegistry {
                 messageFormat: 'anthropic',
                 responseParsePath: 'content[0].text',
                 toolSchemaType: 'anthropic',
+                structuredOutputRequestField: 'output_config',
             },
             active: true
         },
@@ -194,6 +197,7 @@ class ProviderRegistry {
                 messageFormat: 'openai',
                 responseParsePath: 'choices[0].message.content',
                 toolSchemaType: 'openai',
+                structuredOutputRequestField: 'response_format',
             },
             active: true
         },
@@ -224,7 +228,8 @@ class ProviderRegistry {
             chatConfig: {
                 messageFormat: 'openai',
                 responseParsePath: 'response',
-                toolSchemaType: 'openai'
+                toolSchemaType: 'openai',
+                structuredOutputRequestField: 'response_format',
             },
             active: true
         }
@@ -332,6 +337,7 @@ class ProviderRegistry {
                     messageFormat: 'openai',
                     responseParsePath: 'choices[0].message.content',
                     toolSchemaType: 'openai',
+                    structuredOutputRequestField: 'response_format',
                 } as ChatConfig),
             active: config.active !== undefined ? config.active : (existing.active !== undefined ? existing.active : true)
         };

--- a/lib/ResilientLLM.ts
+++ b/lib/ResilientLLM.ts
@@ -5,7 +5,7 @@
  * import { ResilientLLM } from 'resilient-llm';
  * const llm = new ResilientLLM({ aiService: "anthropic", model: "claude-haiku-4-5-20251001", maxTokens: 2048, temperature: 0 });
  * const response = await llm.chat([{ role: "user", content: "Hello, world!" }]);
- * console.log(response);
+ * console.log(response); // string or structured output object
  * // Cancel all llm operations for this instance:
  * llm.abort();
  */
@@ -16,37 +16,30 @@ import { randomUUID } from "node:crypto";
 import ResilientOperation from "./ResilientOperation.js";
 import ProviderRegistry, { type ChatConfig } from "./ProviderRegistry.js";
 import type { RateLimitConfig } from "./RateLimitManager.js";
-import { StructuredOutput } from "./StructuredOutput.js";
+import {
+    normalizeStructuredOutputConfig,
+    mapConfigToRequestFields,
+    parseStructuredResponse,
+    validateStructuredResponse,
+    StructuredOutputError,
+    type ResponseEnvelope,
+    type NormalizedStructuredOutputConfig,
+} from "./StructuredOutput.js";
 
-export type { SchemaValidationIssue } from "./StructuredOutput.js";
+export type { SchemaValidationIssue, StructuredOutputErrorInfo } from "./StructuredOutput.js";
 
-export interface ChatMessage {
-    role: 'system' | 'user' | 'assistant' | 'tool';
-    content: string;
-    [key: string]: unknown;
-}
-
-export interface ResilientLLMOptions {
-    aiService?: string;
-    model?: string;
-    temperature?: number;
-    maxTokens?: number;
-    timeout?: number;
+/**
+ * Options for the ResilientLLM constructor.
+ */
+export interface ResilientLLMOptions extends LLMOptions {
     cacheStore?: Record<string, unknown>;
-    maxInputTokens?: number;
-    topP?: number;
-    maxCompletionTokens?: number;
-    reasoningEffort?: string;
-    retries?: number;
-    backoffFactor?: number;
-    rateLimitConfig?: RateLimitConfig;
-    circuitBreakerConfig?: { failureThreshold?: number; cooldownPeriod?: number };
-    maxConcurrent?: number;
     onRateLimitUpdate?: (rateLimitInfo: RateLimitConfig) => void;
     onError?: (error: Error) => void;
-    returnOperationMetadata?: boolean;
 }
 
+/**
+ * Options for the ResilientLLM.chat method.
+ */
 export interface LLMOptions {
     aiService?: string;
     model?: string;
@@ -64,15 +57,38 @@ export interface LLMOptions {
     maxConcurrent?: number;
     apiKey?: string;
     tools?: ToolDefinition[];
+    /** Recommended structured output option. Accepts string aliases ("json", "object"),
+     *  `{ type: "json_object" }`, or `{ type: "json_schema", schema: ... }`. */
     responseFormat?: unknown;
-    response_format?: unknown;
-    outputConfig?: unknown;
+    /** Migration input for callers transitioning from provider-native APIs.
+     *  Not recommended — use responseFormat instead. */
     output_config?: unknown;
-    parseStructuredOutput?: boolean;
     enableCache?: boolean;
     returnOperationMetadata?: boolean;
 }
 
+/**
+ * Observability related options for the ResilientLLM.chat method.
+ */
+export interface ObservabilityOptions {
+    metadata?: OperationMetadata;
+    [key: string]: unknown;
+}
+
+/**
+ * A message in an LLM chat conversation.
+ * This can be safely cast to the LLM API message object as an input conversation history array item.
+ */
+export interface ChatMessage {
+    role: 'system' | 'user' | 'assistant' | 'tool';
+    content: string;
+    [key: string]: unknown;
+}
+
+/**
+ * A tool definition.
+ * This is the same as the LLM API tool definition object.
+ */
 export interface ToolDefinition {
     type?: string;
     function: {
@@ -83,11 +99,10 @@ export interface ToolDefinition {
     };
 }
 
-export interface ObservabilityOptions {
-    metadata?: OperationMetadata;
-    [key: string]: unknown;
-}
-
+/**
+ * Metadata about the operation.
+ * TODO: Include all the fields from the LLM API operation metadata object as well.
+ */
 export interface OperationMetadata {
     requestId?: string | null;
     operationId?: string;
@@ -105,25 +120,94 @@ export interface OperationMetadata {
     [key: string]: unknown;
 }
 
+/**
+ * Response object returned by the ResilientLLM.chat method when tools are used and/or returnOperationMetadata is true.
+ */
 export interface ChatResponseWithMetadata {
     content: string | Record<string, unknown> | ChatToolCallResult | null;
     metadata: OperationMetadata;
 }
 
+/**
+ * A tool call result.
+ * This is the same as the LLM API tool call result object.
+ */
 export interface ChatToolCallResult {
     content: string | null;
     toolCalls: unknown;
 }
 
+/**
+ * Analysis of the finish reason.
+ */
 interface FinishReasonAnalysis {
     summary: string;
     tokensInfo: string;
     recommendation: string;
 }
 
+/**
+ * HTTP fetch result.
+ */
 interface HttpResult {
     data: Record<string, unknown>;
     statusCode: number;
+}
+
+/**
+ * Effective resilience configuration resolved for one operation.
+ */
+interface EffectiveResilienceConfig {
+    timeout: number;
+    retries: number;
+    backoffFactor: number;
+    circuitBreakerConfig: { failureThreshold?: number; cooldownPeriod?: number };
+    rateLimitConfig: RateLimitConfig;
+    maxConcurrent: number | undefined;
+}
+
+/**
+ * Inputs to build a provider request.
+ */
+interface ChatRequestInput {
+    conversationHistory: ChatMessage[];
+    llmOptions: LLMOptions;
+}
+
+/**
+ * Prepared request returned by the request builder.
+ */
+interface PreparedChatRequest {
+    apiUrl: string;
+    requestBody: Record<string, unknown>;
+    headers: Record<string, string>;
+    chatConfig: ChatConfig;
+    structuredOutputConfig: NormalizedStructuredOutputConfig | null;
+    estimatedTokens: number;
+    aiService: string;
+    model: string;
+    maxInputTokens: number;
+    effectiveResilienceConfig: EffectiveResilienceConfig;
+    enableCache: boolean;
+}
+
+/**
+ * Inputs to parse a raw provider response.
+ */
+interface ChatResponseHandlerInput {
+    rawData: Record<string, unknown>;
+    statusCode: number;
+    chatConfig: ChatConfig;
+    structuredOutputConfig: NormalizedStructuredOutputConfig | null;
+    tools?: ToolDefinition[];
+}
+
+/**
+ * Parsed response returned by the response handler.
+ */
+interface ParsedChatResponse {
+    content: string | Record<string, unknown> | ChatToolCallResult | null;
+    finishReason?: string | null;
 }
 
 /**
@@ -154,6 +238,8 @@ class ResilientLLM {
     returnOperationMetadata: boolean;
     resilientOperations: Record<string, ResilientOperation>;
     llmOutOfService?: string[];
+    responseFormat?: unknown;
+    output_config?: unknown;
 
     private _abortController: AbortController | null;
 
@@ -178,6 +264,8 @@ class ResilientLLM {
         this.maxConcurrent = options?.maxConcurrent;
         this.onRateLimitUpdate = options?.onRateLimitUpdate;
         this.returnOperationMetadata = options?.returnOperationMetadata ?? false;
+        this.responseFormat = options?.responseFormat;
+        this.output_config = options?.output_config;
         this._abortController = null;
         this.resilientOperations = {}; // Store resilient operation instances for observability
     }
@@ -199,8 +287,152 @@ class ResilientLLM {
         const startTime = returnOperationMetadata ? Date.now() : null;
         const requestId = returnOperationMetadata ? randomUUID() : null;
 
-        let requestBody: Record<string, unknown>;
-        let headers: Record<string, string>;
+        let metadata: OperationMetadata | null = null;
+        let resilientOperation: ResilientOperation | null = null;
+
+        try {
+            const preparedRequest = this._buildRequest({
+                conversationHistory,
+                llmOptions,
+            });
+
+            resilientOperation = new ResilientOperation({
+                bucketId: preparedRequest.aiService,
+                ...preparedRequest.effectiveResilienceConfig,
+                collectMetrics: returnOperationMetadata,
+                onRateLimitUpdate: this.onRateLimitUpdate,
+                cacheStore: this.cacheStore
+            });
+
+            if (returnOperationMetadata) {
+                metadata = this._initMetadata({
+                    requestId: requestId!,
+                    startTime: startTime!,
+                    preparedRequest,
+                    llmOptions,
+                    operationId: resilientOperation.id,
+                });
+                observabilityOptions = { ...observabilityOptions, metadata };
+            }
+
+            if (!this._abortController || this._abortController.signal.aborted) {
+                this._abortController = new AbortController();
+            }
+            this.resilientOperations[resilientOperation.id] = resilientOperation;
+
+            const { data, statusCode } = await resilientOperation
+                .withTokens(preparedRequest.estimatedTokens)
+                .withCache(preparedRequest.enableCache)
+                .withAbortControl(this._abortController)
+                .execute(
+                    this._makeHttpRequest as (...args: unknown[]) => Promise<unknown>,
+                    preparedRequest.apiUrl,
+                    preparedRequest.requestBody,
+                    preparedRequest.headers,
+                    this._abortController.signal,
+                    observabilityOptions
+                ) as HttpResult;
+
+            console.log(
+                "LLM chat status code:",
+                statusCode,
+                (data as Record<string, unknown>)?.error
+                    ? ((data as Record<string, unknown>).error as Record<string, unknown>)?.message
+                    : undefined
+            );
+            if ([429, 529].includes(statusCode)) {
+                delete this.resilientOperations[resilientOperation.id];
+                return await this.retryChatWithAlternateService(conversationHistory, llmOptions);
+            }
+
+            const dataAsArray = data as unknown as Record<string, unknown>[];
+            if (data?.error || (Array.isArray(data) && dataAsArray[0]?.error)) {
+                throw new Error(
+                    ((data?.error as Record<string, unknown>)?.message as string) ||
+                    ((dataAsArray?.[0]?.error as Record<string, unknown>)?.message as string)
+                );
+            }
+            if (statusCode !== 200) {
+                // Future: handle other status codes
+            }
+
+            const parsedResponse = this._handleResponse({
+                rawData: data,
+                statusCode,
+                chatConfig: preparedRequest.chatConfig,
+                structuredOutputConfig: preparedRequest.structuredOutputConfig,
+                tools: llmOptions?.tools,
+            });
+            const normalizedContent = parsedResponse.content;
+
+            const effectiveContent = (normalizedContent && typeof normalizedContent === 'object' && 'content' in normalizedContent && 'toolCalls' in normalizedContent)
+                ? (normalizedContent as ChatToolCallResult).content
+                : normalizedContent;
+            const isEmpty = effectiveContent == null || (typeof effectiveContent === 'string' && effectiveContent.trim() === '');
+            if (isEmpty) {
+                console.warn("Empty response from LLM");
+            }
+            const analysis = this._analyzeFinishReason(data);
+            if (analysis) {
+                console.log(analysis.summary);
+                console.log(analysis.tokensInfo);
+                console.log(analysis.recommendation);
+            }
+
+            delete this.resilientOperations[resilientOperation.id];
+
+            if (returnOperationMetadata && metadata) {
+                const usageData = data?.usage && typeof data.usage === 'object'
+                    ? (data.usage as Record<string, unknown>)
+                    : {};
+                metadata = this._finalizeMetadata(
+                    metadata,
+                    'success',
+                    resilientOperation.getRuntimeMetrics(),
+                    usageData,
+                );
+                return { content: normalizedContent as string | Record<string, unknown> | ChatToolCallResult | null, metadata } as ChatResponseWithMetadata;
+            }
+            return normalizedContent;
+        } catch (error) {
+            const aiService = llmOptions?.aiService || this.aiService;
+            console.error(`Error calling ${aiService} API:`, error);
+            if (resilientOperation) {
+                delete this.resilientOperations[resilientOperation.id];
+            }
+            if (returnOperationMetadata && metadata) {
+                metadata = this._finalizeMetadata(
+                    metadata,
+                    'error',
+                    resilientOperation?.getRuntimeMetrics() ?? null,
+                );
+            }
+            this.parseError(null, error as Error, returnOperationMetadata ? metadata : null);
+            return null; // unreachable since parseError always throws, but satisfies TS
+        }
+    }
+
+    /** Resolves resilience settings from instance defaults and per-call overrides. */
+    private _resolveResilienceConfig(llmOptions: LLMOptions): EffectiveResilienceConfig {
+        return {
+            timeout: Number(llmOptions?.timeout ?? this.timeout),
+            retries: llmOptions?.retries ?? this.retries,
+            backoffFactor: llmOptions?.backoffFactor ?? this.backoffFactor,
+            circuitBreakerConfig: {
+                failureThreshold: llmOptions?.circuitBreakerConfig?.failureThreshold ?? this.circuitBreakerConfig?.failureThreshold,
+                cooldownPeriod: llmOptions?.circuitBreakerConfig?.cooldownPeriod ?? this.circuitBreakerConfig?.cooldownPeriod
+            },
+            rateLimitConfig: {
+                requestsPerMinute: llmOptions?.rateLimitConfig?.requestsPerMinute ?? this.rateLimitConfig?.requestsPerMinute,
+                llmTokensPerMinute: llmOptions?.rateLimitConfig?.llmTokensPerMinute ?? this.rateLimitConfig?.llmTokensPerMinute
+            },
+            maxConcurrent: llmOptions?.maxConcurrent ?? this.maxConcurrent,
+        };
+    }
+
+    /** Builds provider request data from explicit chat inputs and defaults. */
+    private _buildRequest(input: ChatRequestInput): PreparedChatRequest {
+        const { conversationHistory, llmOptions } = input;
         const aiService = llmOptions?.aiService || this.aiService;
         const model = llmOptions?.model || this.model;
 
@@ -239,40 +471,50 @@ class ResilientLLM {
         apiUrl = ProviderRegistry.buildApiUrl(aiService, apiUrl, apiKey);
 
         const maxInputTokens = Number(llmOptions?.maxInputTokens || this.maxInputTokens);
-
         // Estimate LLM tokens for this request
-        const estimatedLLMTokens = ResilientLLM.estimateTokens(conversationHistory?.map(message => message?.content)?.join("\n"));
-        console.log("Estimated LLM input tokens:", estimatedLLMTokens, "/", maxInputTokens);
-        if (estimatedLLMTokens > maxInputTokens) {
+        const estimatedTokens = ResilientLLM.estimateTokens(
+            conversationHistory?.map(message => message?.content)?.join("\n")
+        );
+        console.log("Estimated LLM input tokens:", estimatedTokens, "/", maxInputTokens);
+        if (estimatedTokens > maxInputTokens) {
             throw new Error("Input tokens exceed the maximum limit of " + maxInputTokens);
         }
 
-        requestBody = {
-            model: model
-        };
-
+        const requestBody: Record<string, unknown> = { model };
         if (llmOptions?.tools) {
             requestBody.tools = llmOptions.tools;
         }
-        // Accept both JS-style camelCase and HTTP-style snake_case aliases.
-        // StructuredOutput normalizes these and rejects ambiguous duplicates.
-        const structuredOutput = StructuredOutput.fromInputs({
-            responseFormat: llmOptions?.responseFormat,
-            response_format: llmOptions?.response_format,
-            outputConfig: llmOptions?.outputConfig,
-            output_config: llmOptions?.output_config,
-        });
-        const requestField = chatConfig.structuredOutputRequestField || 'response_format';
-        const { responseFormat, outputConfig } = structuredOutput.getRequestFields(requestField);
-        if (responseFormat !== undefined) {
-            requestBody.response_format = responseFormat;
+
+        const structuredOutputConfigResult = normalizeStructuredOutputConfig(
+            llmOptions?.responseFormat ?? this.responseFormat,
+            llmOptions?.output_config ?? this.output_config,
+        );
+        if (!structuredOutputConfigResult.ok) {
+            throw new StructuredOutputError(structuredOutputConfigResult.error);
         }
-        if (outputConfig !== undefined) {
-            requestBody.output_config = outputConfig;
+        const normalizedStructuredOutputConfig = structuredOutputConfigResult.data;
+        const structuredOutputConfig = normalizedStructuredOutputConfig._source === 'none'
+            ? null
+            : normalizedStructuredOutputConfig;
+
+        // Map structured output config to provider request fields
+        const structuredRequestFields = mapConfigToRequestFields(
+            normalizedStructuredOutputConfig,
+            chatConfig.structuredOutputRequestField ?? 'response_format'
+        );
+        if (structuredRequestFields.response_format !== undefined) {
+            requestBody.response_format = structuredRequestFields.response_format;
         }
+        if (structuredRequestFields.output_config !== undefined) {
+            requestBody.output_config = structuredRequestFields.output_config;
+        }
+
         if (model?.startsWith("o") || model?.startsWith("gpt-5")) {
             // Reasoning model parameters
-            const maxCompletionTokens = llmOptions?.maxCompletionTokens ?? this.maxCompletionTokens ?? llmOptions?.maxTokens ?? this.maxTokens;
+            const maxCompletionTokens = llmOptions?.maxCompletionTokens
+                ?? this.maxCompletionTokens
+                ?? llmOptions?.maxTokens
+                ?? this.maxTokens;
             if (maxCompletionTokens != null) {
                 requestBody.max_completion_tokens = Number(maxCompletionTokens);
             }
@@ -331,152 +573,191 @@ class ResilientLLM {
         const defaultHeaders: Record<string, string> = {
             'Content-Type': 'application/json'
         };
-        headers = ProviderRegistry.buildAuthHeaders(aiService, apiKey, defaultHeaders, apiUrl);
+        const headers = ProviderRegistry.buildAuthHeaders(aiService, apiKey, defaultHeaders, apiUrl);
 
-        const effectiveResilienceConfig = {
-            timeout: Number(llmOptions?.timeout ?? this.timeout),
-            retries: llmOptions?.retries ?? this.retries,
-            backoffFactor: llmOptions?.backoffFactor ?? this.backoffFactor,
-            circuitBreakerConfig: {
-                failureThreshold: llmOptions?.circuitBreakerConfig?.failureThreshold ?? this.circuitBreakerConfig?.failureThreshold,
-                cooldownPeriod: llmOptions?.circuitBreakerConfig?.cooldownPeriod ?? this.circuitBreakerConfig?.cooldownPeriod
+        return {
+            apiUrl,
+            requestBody,
+            headers,
+            chatConfig,
+            structuredOutputConfig,
+            estimatedTokens,
+            aiService,
+            model,
+            maxInputTokens,
+            effectiveResilienceConfig: this._resolveResilienceConfig(llmOptions),
+            enableCache: llmOptions?.enableCache ?? true,
+        };
+    }
+
+    /** Parses and normalizes the provider response into caller-facing content. */
+    private _handleResponse(input: ChatResponseHandlerInput): ParsedChatResponse {
+        const envelope = this.parseChatCompletion(input.rawData, input.chatConfig, input.tools);
+        let normalizedContent: string | Record<string, unknown> | ChatToolCallResult | null;
+
+        if (envelope.toolCalls) {
+            normalizedContent = { content: envelope.content, toolCalls: envelope.toolCalls };
+        } else if (input.structuredOutputConfig && input.structuredOutputConfig.expectsJson) {
+            const parseResult = parseStructuredResponse(envelope, input.structuredOutputConfig);
+            if (!parseResult.ok) {
+                console.error(
+                    "[ResilientLLM][_handleResponse] Structured output parsing failed",
+                    {
+                        structuredOutputConfig: input.structuredOutputConfig,
+                        envelopeContent: envelope.content,
+                        // Raw provider payload to debug response-shape mismatches.
+                        rawProviderResponse: input.rawData,
+                        rawResponseForError: (parseResult.error as any)?.rawResponse ?? undefined,
+                        structuredOutputError: {
+                            code: (parseResult.error as any)?.code ?? undefined,
+                            message: parseResult.error.message,
+                            validation: (parseResult.error as any)?.validation ?? null,
+                        }
+                    }
+                );
+                throw new StructuredOutputError(parseResult.error);
+            }
+
+            if (
+                parseResult.data &&
+                typeof parseResult.data === 'object' &&
+                !(Array.isArray(parseResult.data))
+            ) {
+                const validateResult = validateStructuredResponse(
+                    parseResult.data as Record<string, unknown>,
+                    input.structuredOutputConfig,
+                );
+                if (!validateResult.ok) {
+                    console.error(
+                        "[ResilientLLM][_handleResponse] Structured output validation failed",
+                        {
+                            structuredOutputConfig: input.structuredOutputConfig,
+                            parsedJson: parseResult.data,
+                            envelopeContent: envelope.content,
+                            rawProviderResponse: input.rawData,
+                            validationError: validateResult.error,
+                        }
+                    );
+                    throw new StructuredOutputError(validateResult.error);
+                }
+                normalizedContent = validateResult.data;
+            } else {
+                normalizedContent = parseResult.data as string | null;
+            }
+        } else {
+            normalizedContent = envelope.content ?? null;
+        }
+
+        return {
+            content: normalizedContent,
+            finishReason: envelope.finishReason ?? null,
+        };
+    }
+
+    /** Initializes operation metadata before request execution starts. */
+    private _initMetadata(params: {
+        requestId: string;
+        startTime: number;
+        preparedRequest: PreparedChatRequest;
+        llmOptions: LLMOptions;
+        operationId: string;
+    }): OperationMetadata {
+        const { requestId, startTime, preparedRequest, llmOptions, operationId } = params;
+        const temperature = llmOptions?.temperature ?? this.temperature;
+        const topP = llmOptions?.topP ?? this.topP;
+        const effectiveMaxTokens = (preparedRequest.requestBody.max_completion_tokens
+            ?? preparedRequest.requestBody.max_tokens
+            ?? null) as number | null;
+
+        return {
+            requestId,
+            operationId,
+            startTime,
+            config: {
+                aiService: preparedRequest.aiService,
+                model: preparedRequest.model,
+                temperature: temperature != null ? Number(temperature) : null,
+                maxTokens: effectiveMaxTokens,
+                topP: topP != null ? Number(topP) : null,
+                maxInputTokens: preparedRequest.maxInputTokens,
+                estimatedInputTokens: preparedRequest.estimatedTokens,
+                enableCache: preparedRequest.enableCache,
+                ...preparedRequest.effectiveResilienceConfig,
             },
-            rateLimitConfig: {
-                requestsPerMinute: llmOptions?.rateLimitConfig?.requestsPerMinute ?? this.rateLimitConfig?.requestsPerMinute,
-                llmTokensPerMinute: llmOptions?.rateLimitConfig?.llmTokensPerMinute ?? this.rateLimitConfig?.llmTokensPerMinute
-            },
-            maxConcurrent: llmOptions?.maxConcurrent ?? this.maxConcurrent,
+            events: [],
+            timing: { totalTimeMs: null, rateLimitWaitMs: 0, httpRequestMs: null },
+            retries: [],
+            rateLimiting: { requestedTokens: preparedRequest.estimatedTokens, totalWaitMs: 0 },
+            circuitBreaker: {},
+            http: {},
+            cache: { enabled: preparedRequest.enableCache },
+            service: { attempted: [preparedRequest.aiService], final: preparedRequest.aiService },
+        };
+    }
+
+    /** Finalizes metadata by merging runtime metrics and computing total timing. */
+    private _finalizeMetadata(
+        base: OperationMetadata,
+        phase: 'success' | 'error',
+        runtimeMetrics: ReturnType<ResilientOperation['getRuntimeMetrics']> | null,
+        usageData?: Record<string, unknown>,
+    ): OperationMetadata {
+        const prev = base ?? {};
+        const timingPrev = prev.timing ?? {};
+        const totalTimeMs = typeof prev.startTime === 'number'
+            ? Date.now() - prev.startTime
+            : timingPrev.totalTimeMs ?? null;
+
+        const timing = {
+            totalTimeMs,
+            rateLimitWaitMs: runtimeMetrics?.rateLimiting?.totalWaitMs ?? timingPrev.rateLimitWaitMs ?? 0,
+            httpRequestMs: timingPrev.httpRequestMs ?? null,
         };
 
-        let metadata: OperationMetadata | null = null;
-        let resilientOperation: ResilientOperation | null = null;
-        try {
-            resilientOperation = new ResilientOperation({
-                bucketId: llmOptions?.aiService || this.aiService,
-                ...effectiveResilienceConfig,
-                collectMetrics: returnOperationMetadata,
-                onRateLimitUpdate: this.onRateLimitUpdate,
-                cacheStore: this.cacheStore
-            });
+        const rateLimiting = {
+            requestedTokens: prev.rateLimiting?.requestedTokens ?? runtimeMetrics?.rateLimiting?.requestedTokens ?? 0,
+            totalWaitMs: runtimeMetrics?.rateLimiting?.totalWaitMs
+                ?? prev.rateLimiting?.totalWaitMs
+                ?? 0,
+        };
 
-            if (returnOperationMetadata) {
-                const temperature = llmOptions?.temperature ?? this.temperature;
-                const topP = llmOptions?.topP ?? this.topP;
-                const effectiveMaxTokens = (requestBody.max_completion_tokens ?? requestBody.max_tokens ?? null) as number | null;
-                const enableCache = llmOptions?.enableCache ?? true;
-                metadata = {
-                    requestId,
-                    operationId: resilientOperation.id,
-                    startTime,
-                    config: {
-                        aiService,
-                        model,
-                        temperature: temperature != null ? Number(temperature) : null,
-                        maxTokens: effectiveMaxTokens,
-                        topP: topP != null ? Number(topP) : null,
-                        maxInputTokens,
-                        estimatedInputTokens: estimatedLLMTokens,
-                        enableCache,
-                        ...effectiveResilienceConfig,
-                    },
-                    events: [],
-                    timing: { totalTimeMs: null, rateLimitWaitMs: 0, httpRequestMs: null },
-                    retries: [],
-                    rateLimiting: { requestedTokens: estimatedLLMTokens, totalWaitMs: 0 },
-                    circuitBreaker: {},
-                    http: {},
-                    cache: { enabled: enableCache },
-                    service: { attempted: [aiService], final: aiService },
-                };
-                observabilityOptions = { ...observabilityOptions, metadata };
-            }
+        const circuitBreaker = {
+            ...(prev.circuitBreaker ?? {}),
+            ...(runtimeMetrics?.circuitBreaker as unknown as Record<string, unknown> | null ?? {}),
+        };
 
-            if (!this._abortController || this._abortController.signal.aborted) {
-                this._abortController = new AbortController();
-            }
-            this.resilientOperations[resilientOperation.id] = resilientOperation;
-            const { data, statusCode } = await resilientOperation
-                .withTokens(estimatedLLMTokens)
-                .withCache(llmOptions?.enableCache ?? true)
-                .withAbortControl(this._abortController)
-                .execute(
-                    this._makeHttpRequest as (...args: unknown[]) => Promise<unknown>,
-                    apiUrl, requestBody, headers, this._abortController.signal, observabilityOptions
-                ) as HttpResult;
+        const cache = {
+            ...(prev.cache ?? {}),
+            ...(runtimeMetrics?.cache ?? {}),
+        };
 
-            console.log("LLM chat status code:", statusCode, (data as Record<string, unknown>)?.error ? ((data as Record<string, unknown>).error as Record<string, unknown>)?.message : undefined);
-            if ([429, 529].includes(statusCode)) {
-                return await this.retryChatWithAlternateService(conversationHistory, llmOptions);
-            }
-            const dataAsArray = data as unknown as Record<string, unknown>[];
-            if (data?.error || (Array.isArray(data) && dataAsArray[0]?.error)) {
-                throw new Error(
-                    ((data?.error as Record<string, unknown>)?.message as string) ||
-                    ((dataAsArray?.[0]?.error as Record<string, unknown>)?.message as string)
-                );
-            }
-            if (statusCode !== 200) {
-                // Future: handle other status codes
-            }
+        const usage =
+            phase === 'success' && usageData && typeof usageData === 'object'
+                ? (() => {
+                      const pt = usageData.prompt_tokens as number | undefined;
+                      const ct = usageData.completion_tokens as number | undefined;
+                      const tot =
+                          (usageData.total_tokens as number | undefined) ??
+                          (pt != null && ct != null ? pt + ct : null);
+                      return {
+                          prompt_tokens: pt ?? null,
+                          completion_tokens: ct ?? null,
+                          total_tokens: tot ?? null,
+                      };
+                  })()
+                : prev.usage;
+        const retries = runtimeMetrics?.retries ?? prev.retries ?? [];
 
-            const content = this.parseChatCompletion(data, chatConfig, llmOptions?.tools);
-            const shouldParseStructuredOutput = llmOptions?.parseStructuredOutput ?? true;
-            const normalizedContent = shouldParseStructuredOutput ? structuredOutput.parse(content) : content;
-            const effectiveContent = (normalizedContent && typeof normalizedContent === 'object' && 'content' in normalizedContent)
-                ? (normalizedContent as ChatToolCallResult).content
-                : normalizedContent;
-            const isEmpty = effectiveContent == null || (typeof effectiveContent === 'string' && effectiveContent.trim() === '');
-            if (isEmpty) {
-                console.warn("Empty response from LLM");
-            }
-            const analysis = this._analyzeFinishReason(data);
-            if (analysis) {
-                console.log(analysis.summary);
-                console.log(analysis.tokensInfo);
-                console.log(analysis.recommendation);
-            }
-
-            delete this.resilientOperations[resilientOperation.id];
-
-            if (returnOperationMetadata && metadata) {
-                const runtimeMetrics = resilientOperation.getRuntimeMetrics();
-                const usageData = data?.usage && typeof data.usage === 'object'
-                    ? (data.usage as Record<string, unknown>)
-                    : {};
-
-                metadata = ResilientLLM._buildOperationMetadata({
-                    base: metadata,
-                    aiService,
-                    estimatedLLMTokens,
-                    startTime: startTime!,
-                    now: Date.now(),
-                    runtimeMetrics,
-                    usageData,
-                    phase: 'success',
-                    llmOptions,
-                });
-
-                return { content: normalizedContent as string | Record<string, unknown> | ChatToolCallResult | null, metadata } as ChatResponseWithMetadata;
-            }
-            return normalizedContent;
-        } catch (error) {
-            console.error(`Error calling ${aiService} API:`, error);
-            if (returnOperationMetadata && metadata) {
-                const runtimeMetrics = resilientOperation?.getRuntimeMetrics() ?? null;
-                metadata = ResilientLLM._buildOperationMetadata({
-                    base: metadata,
-                    aiService,
-                    estimatedLLMTokens,
-                    startTime: startTime!,
-                    now: Date.now(),
-                    runtimeMetrics,
-                    phase: 'error',
-                    llmOptions,
-                });
-            }
-            this.parseError(null, error as Error, returnOperationMetadata ? metadata : null);
-            return null; // unreachable since parseError always throws, but satisfies TS
-        }
+        return {
+            ...prev,
+            timing,
+            retries,
+            rateLimiting,
+            circuitBreaker,
+            cache,
+            usage,
+            service: prev.service ?? { attempted: [this.aiService], final: this.aiService },
+        };
     }
 
     async retryChatWithAlternateService(
@@ -547,89 +828,6 @@ class ResilientLLM {
             console.error(`Error in request to ${apiUrl}:`, error);
             throw error;
         }
-    }
-
-    /**
-     * Builds the operation metadata object.
-     */
-    private static _buildOperationMetadata(params: {
-        base: OperationMetadata | null;
-        aiService: string;
-        estimatedLLMTokens: number;
-        startTime: number;
-        now: number;
-        runtimeMetrics: ReturnType<ResilientOperation['getRuntimeMetrics']> | null;
-        usageData?: Record<string, unknown>;
-        phase: 'success' | 'error';
-        llmOptions: LLMOptions;
-    }): OperationMetadata {
-        const {
-            base,
-            aiService,
-            estimatedLLMTokens,
-            startTime,
-            now,
-            runtimeMetrics,
-            usageData,
-            phase,
-            llmOptions,
-        } = params;
-
-        const prev = base ?? {};
-
-        const timingPrev = prev.timing ?? {};
-        const totalTimeMs = now - startTime;
-
-        const timing = {
-            totalTimeMs,
-            rateLimitWaitMs: runtimeMetrics?.rateLimiting?.totalWaitMs ?? timingPrev.rateLimitWaitMs ?? 0,
-            httpRequestMs: timingPrev.httpRequestMs ?? null,
-        };
-
-        const rateLimiting = {
-            requestedTokens: prev.rateLimiting?.requestedTokens ?? estimatedLLMTokens,
-            totalWaitMs: runtimeMetrics?.rateLimiting?.totalWaitMs
-                ?? prev.rateLimiting?.totalWaitMs
-                ?? 0,
-        };
-
-        const circuitBreaker = {
-            ...(prev.circuitBreaker ?? {}),
-            ...(runtimeMetrics?.circuitBreaker as unknown as Record<string, unknown> | null ?? {}),
-        };
-
-        const cache = {
-            ...(prev.cache ?? { enabled: llmOptions?.enableCache ?? true }),
-            ...(runtimeMetrics?.cache ?? {}),
-        };
-
-        const usage =
-            phase === 'success' && usageData && typeof usageData === 'object'
-                ? (() => {
-                      const pt = usageData.prompt_tokens as number | undefined;
-                      const ct = usageData.completion_tokens as number | undefined;
-                      const tot =
-                          (usageData.total_tokens as number | undefined) ??
-                          (pt != null && ct != null ? pt + ct : null);
-                      return {
-                          prompt_tokens: pt ?? null,
-                          completion_tokens: ct ?? null,
-                          total_tokens: tot ?? null,
-                      };
-                  })()
-                : prev.usage;
-
-        const service = prev.service ?? { attempted: [aiService], final: aiService };
-
-        return {
-            ...prev,
-            timing,
-            rateLimiting,
-            circuitBreaker,
-            cache,
-            usage,
-            service,
-        };
     }
 
     static _captureHttpMetadata(
@@ -845,36 +1043,35 @@ class ResilientLLM {
     }
 
     /**
-     * The standard method to parse OpenAI-compatible chat completion response using provider configuration
-     * @param {Object} data - Response data from API
-     * @param {Object} chatConfig - Chat configuration from provider
-     * @param {boolean|Array} tools - Whether tools are enabled or tool definitions
-     * @returns {string|Object} Parsed content or object with content and toolCalls
+     * Extracts provider response into a normalized envelope for downstream processing.
+     * Responsible for content extraction and tool-call detection only — no schema logic.
      */
     parseChatCompletion(
         data: Record<string, unknown>,
         chatConfig: ChatConfig,
         tools?: ToolDefinition[]
-    ): string | ChatToolCallResult | null {
+    ): ResponseEnvelope {
         if (!data) {
-            return null;
+            return { content: null };
         }
 
         const parsePath = chatConfig?.responseParsePath || 'choices[0].message.content';
         const content = this._getNestedValue(data, parsePath) as string | null;
 
+        const choices = data?.choices as Record<string, unknown>[] | undefined;
+        const finishReason = (choices?.[0]?.finish_reason as string) ?? null;
+
         if (tools) {
-            const choices = data?.choices as Record<string, unknown>[] | undefined;
             const dataContent = data?.content as Record<string, unknown>[] | undefined;
             const toolCalls = choices?.[0]?.message
                 ? (choices[0].message as Record<string, unknown>)?.tool_calls
                 : dataContent?.[0]?.tool_use || null;
             if (toolCalls) {
-                return { content, toolCalls };
+                return { content, toolCalls, finishReason };
             }
         }
 
-        return content;
+        return { content, finishReason };
     }
 
     /**

--- a/lib/ResilientLLM.ts
+++ b/lib/ResilientLLM.ts
@@ -62,7 +62,6 @@ export interface LLMOptions {
     apiKey?: string;
     tools?: ToolDefinition[];
     responseFormat?: unknown;
-    schema?: unknown;
     enableCache?: boolean;
     returnOperationMetadata?: boolean;
 }
@@ -419,42 +418,39 @@ class ResilientLLM {
 
             if (returnOperationMetadata && metadata) {
                 const runtimeMetrics = resilientOperation.getRuntimeMetrics();
-                if (runtimeMetrics) {
-                    metadata.retries = runtimeMetrics.retries;
-                    metadata.rateLimiting = { ...metadata.rateLimiting, ...runtimeMetrics.rateLimiting };
-                    metadata.circuitBreaker = runtimeMetrics.circuitBreaker as unknown as Record<string, unknown>;
-                    metadata.cache = { enabled: llmOptions?.enableCache ?? true, ...runtimeMetrics.cache };
-                    metadata.timing!.rateLimitWaitMs = runtimeMetrics.rateLimiting?.totalWaitMs ?? 0;
-                }
-                metadata.timing!.totalTimeMs = Date.now() - startTime!;
-                const usageData = data?.usage && typeof data.usage === 'object' ? data.usage as Record<string, unknown> : {};
-                const pt = usageData.prompt_tokens as number | undefined;
-                const ct = usageData.completion_tokens as number | undefined;
-                const tot = (usageData.total_tokens as number | undefined) ?? (pt != null && ct != null ? pt + ct : null);
-                metadata.usage = {
-                    prompt_tokens: pt ?? null,
-                    completion_tokens: ct ?? null,
-                    total_tokens: tot ?? null,
-                };
+                const usageData = data?.usage && typeof data.usage === 'object'
+                    ? (data.usage as Record<string, unknown>)
+                    : {};
+
+                metadata = ResilientLLM._buildOperationMetadata({
+                    base: metadata,
+                    aiService,
+                    estimatedLLMTokens,
+                    startTime: startTime!,
+                    now: Date.now(),
+                    runtimeMetrics,
+                    usageData,
+                    phase: 'success',
+                    llmOptions,
+                });
+
                 return { content, metadata } as ChatResponseWithMetadata;
             }
             return content;
         } catch (error) {
             console.error(`Error calling ${aiService} API:`, error);
             if (returnOperationMetadata && metadata) {
-                metadata.timing!.totalTimeMs = Date.now() - startTime!;
-                try {
-                    const runtimeMetrics = resilientOperation?.getRuntimeMetrics();
-                    if (runtimeMetrics) {
-                        metadata.retries = runtimeMetrics.retries;
-                        metadata.rateLimiting = { ...metadata.rateLimiting, ...runtimeMetrics.rateLimiting };
-                        metadata.circuitBreaker = runtimeMetrics.circuitBreaker as unknown as Record<string, unknown>;
-                        metadata.cache = { ...metadata.cache, ...runtimeMetrics.cache };
-                        metadata.timing!.rateLimitWaitMs = runtimeMetrics.rateLimiting?.totalWaitMs ?? 0;
-                    }
-                } catch (_) {
-                    // resilientOperation may be missing or not have metrics
-                }
+                const runtimeMetrics = resilientOperation?.getRuntimeMetrics() ?? null;
+                metadata = ResilientLLM._buildOperationMetadata({
+                    base: metadata,
+                    aiService,
+                    estimatedLLMTokens,
+                    startTime: startTime!,
+                    now: Date.now(),
+                    runtimeMetrics,
+                    phase: 'error',
+                    llmOptions,
+                });
             }
             this.parseError(null, error as Error, returnOperationMetadata ? metadata : null);
             return null; // unreachable since parseError always throws, but satisfies TS
@@ -531,6 +527,86 @@ class ResilientLLM {
         }
     }
 
+    private static _buildOperationMetadata(params: {
+        base: OperationMetadata | null;
+        aiService: string;
+        estimatedLLMTokens: number;
+        startTime: number;
+        now: number;
+        runtimeMetrics: ReturnType<ResilientOperation['getRuntimeMetrics']> | null;
+        usageData?: Record<string, unknown>;
+        phase: 'success' | 'error';
+        llmOptions: LLMOptions;
+    }): OperationMetadata {
+        const {
+            base,
+            aiService,
+            estimatedLLMTokens,
+            startTime,
+            now,
+            runtimeMetrics,
+            usageData,
+            phase,
+            llmOptions,
+        } = params;
+
+        const prev = base ?? {};
+
+        const timingPrev = prev.timing ?? {};
+        const totalTimeMs = now - startTime;
+
+        const timing = {
+            totalTimeMs,
+            rateLimitWaitMs: runtimeMetrics?.rateLimiting?.totalWaitMs ?? timingPrev.rateLimitWaitMs ?? 0,
+            httpRequestMs: timingPrev.httpRequestMs ?? null,
+        };
+
+        const rateLimiting = {
+            requestedTokens: prev.rateLimiting?.requestedTokens ?? estimatedLLMTokens,
+            totalWaitMs: runtimeMetrics?.rateLimiting?.totalWaitMs
+                ?? prev.rateLimiting?.totalWaitMs
+                ?? 0,
+        };
+
+        const circuitBreaker = {
+            ...(prev.circuitBreaker ?? {}),
+            ...(runtimeMetrics?.circuitBreaker as unknown as Record<string, unknown> | null ?? {}),
+        };
+
+        const cache = {
+            ...(prev.cache ?? { enabled: llmOptions?.enableCache ?? true }),
+            ...(runtimeMetrics?.cache ?? {}),
+        };
+
+        const usage =
+            phase === 'success' && usageData && typeof usageData === 'object'
+                ? (() => {
+                      const pt = usageData.prompt_tokens as number | undefined;
+                      const ct = usageData.completion_tokens as number | undefined;
+                      const tot =
+                          (usageData.total_tokens as number | undefined) ??
+                          (pt != null && ct != null ? pt + ct : null);
+                      return {
+                          prompt_tokens: pt ?? null,
+                          completion_tokens: ct ?? null,
+                          total_tokens: tot ?? null,
+                      };
+                  })()
+                : prev.usage;
+
+        const service = prev.service ?? { attempted: [aiService], final: aiService };
+
+        return {
+            ...prev,
+            timing,
+            rateLimiting,
+            circuitBreaker,
+            cache,
+            usage,
+            service,
+        };
+    }
+
     static _captureHttpMetadata(
         metadata: OperationMetadata,
         apiUrl: string,
@@ -565,7 +641,10 @@ class ResilientLLM {
             durationMs,
             ...(error ? { error: error.message } : {}),
         };
-        metadata.timing!.httpRequestMs = durationMs;
+        if (!metadata.timing) {
+            metadata.timing = { totalTimeMs: null, rateLimitWaitMs: 0, httpRequestMs: null };
+        }
+        metadata.timing.httpRequestMs = durationMs;
     }
 
     parseError(statusCode: number | null, error: Error, operationMetadata?: OperationMetadata | null): never {

--- a/lib/ResilientLLM.ts
+++ b/lib/ResilientLLM.ts
@@ -5,7 +5,8 @@
  * import { ResilientLLM } from 'resilient-llm';
  * const llm = new ResilientLLM({ aiService: "anthropic", model: "claude-haiku-4-5-20251001", maxTokens: 2048, temperature: 0 });
  * const response = await llm.chat([{ role: "user", content: "Hello, world!" }]);
- * console.log(response); // string or structured output object
+ * console.log(response.content); // assistant output
+ * // response.metadata is always included for observability
  * // Cancel all llm operations for this instance:
  * llm.abort();
  */
@@ -64,7 +65,6 @@ export interface LLMOptions {
      *  Not recommended — use responseFormat instead. */
     output_config?: unknown;
     enableCache?: boolean;
-    returnOperationMetadata?: boolean;
 }
 
 /**
@@ -107,6 +107,8 @@ export interface OperationMetadata {
     requestId?: string | null;
     operationId?: string;
     startTime?: number | null;
+    /** LLM finish reason semantics (e.g. `stop`, `tool_calls`, `length`). */
+    finishReason?: string | null;
     config?: Record<string, unknown>;
     events?: unknown[];
     timing?: { totalTimeMs?: number | null; rateLimitWaitMs?: number; httpRequestMs?: number | null };
@@ -121,10 +123,17 @@ export interface OperationMetadata {
 }
 
 /**
- * Response object returned by the ResilientLLM.chat method when tools are used and/or returnOperationMetadata is true.
+ * Always-structured response envelope returned by `ResilientLLM.chat()`.
+ *
+ * - `content` is the parsed/normalized assistant content:
+ *   - text mode -> string
+ *   - JSON/schema mode -> parsed JS object
+ * - `toolCalls` is present when tool calls were returned by the model.
+ * - `metadata` is always included.
  */
-export interface ChatResponseWithMetadata {
-    content: string | Record<string, unknown> | ChatToolCallResult | null;
+export interface ChatResponse {
+    content: string | Record<string, unknown> | null;
+    toolCalls?: unknown;
     metadata: OperationMetadata;
 }
 
@@ -157,7 +166,7 @@ interface HttpResult {
 /**
  * Effective resilience configuration resolved for one operation.
  */
-interface EffectiveResilienceConfig {
+interface ResilienceConfig {
     timeout: number;
     retries: number;
     backoffFactor: number;
@@ -187,7 +196,7 @@ interface PreparedChatRequest {
     aiService: string;
     model: string;
     maxInputTokens: number;
-    effectiveResilienceConfig: EffectiveResilienceConfig;
+    resilienceConfig: ResilienceConfig;
     enableCache: boolean;
 }
 
@@ -206,14 +215,17 @@ interface ChatResponseHandlerInput {
  * Parsed response returned by the response handler.
  */
 interface ParsedChatResponse {
-    content: string | Record<string, unknown> | ChatToolCallResult | null;
+    /** Assistant payload only (never tool-call wrapper). */
+    content: string | Record<string, unknown> | null;
+    /** Tool calls normalized to a top-level payload (when tools were returned). */
+    toolCalls?: unknown;
     finishReason?: string | null;
 }
 
 /**
  * ResilientLLM: unified chat interface with configurable provider, model, rate limits, circuit breaker, and retries.
  * Constructor options: aiService, model, temperature, maxTokens, timeout, cacheStore, maxInputTokens, topP,
- * rateLimitConfig, retries, backoffFactor, circuitBreakerConfig, maxConcurrent, onRateLimitUpdate, returnOperationMetadata.
+ * rateLimitConfig, retries, backoffFactor, circuitBreakerConfig, maxConcurrent, onRateLimitUpdate.
  */
 class ResilientLLM {
     static encoder: Tiktoken | undefined;
@@ -235,7 +247,6 @@ class ResilientLLM {
     circuitBreakerConfig: { failureThreshold: number; cooldownPeriod: number };
     maxConcurrent: number | undefined;
     onRateLimitUpdate: ((rateLimitInfo: RateLimitConfig) => void) | undefined;
-    returnOperationMetadata: boolean;
     resilientOperations: Record<string, ResilientOperation>;
     llmOutOfService?: string[];
     responseFormat?: unknown;
@@ -263,7 +274,6 @@ class ResilientLLM {
             : { failureThreshold: 5, cooldownPeriod: 30000 };
         this.maxConcurrent = options?.maxConcurrent;
         this.onRateLimitUpdate = options?.onRateLimitUpdate;
-        this.returnOperationMetadata = options?.returnOperationMetadata ?? false;
         this.responseFormat = options?.responseFormat;
         this.output_config = options?.output_config;
         this._abortController = null;
@@ -273,19 +283,17 @@ class ResilientLLM {
     /**
      * Chat with the LLM.
      * @param conversationHistory - Array of messages (role + content)
-     * @param llmOptions - Overrides for this call (model, temperature, tools, apiKey, returnOperationMetadata, etc.)
+     * @param llmOptions - Overrides for this call (model, temperature, tools, apiKey, etc.)
      * @param observabilityOptions - Observability/metadata options
-     * @returns Response content, or { content, metadata } when returnOperationMetadata is true
+     * @returns A response envelope: `{ content, toolCalls?, metadata }`
      */
     async chat(
         conversationHistory: ChatMessage[],
         llmOptions: LLMOptions = {},
         observabilityOptions: ObservabilityOptions = {}
-    ): Promise<string | Record<string, unknown> | ChatToolCallResult | ChatResponseWithMetadata | null> {
-        // TODO: Support dynamic selection/correction of params (e.g. reasoning vs non-reasoning models);
-        const returnOperationMetadata = llmOptions?.returnOperationMetadata ?? this.returnOperationMetadata ?? false;
-        const startTime = returnOperationMetadata ? Date.now() : null;
-        const requestId = returnOperationMetadata ? randomUUID() : null;
+    ): Promise<ChatResponse> {
+        const startTime = Date.now();
+        const requestId = randomUUID();
 
         let metadata: OperationMetadata | null = null;
         let resilientOperation: ResilientOperation | null = null;
@@ -298,22 +306,20 @@ class ResilientLLM {
 
             resilientOperation = new ResilientOperation({
                 bucketId: preparedRequest.aiService,
-                ...preparedRequest.effectiveResilienceConfig,
-                collectMetrics: returnOperationMetadata,
+                ...preparedRequest.resilienceConfig,
+                collectMetrics: true,
                 onRateLimitUpdate: this.onRateLimitUpdate,
                 cacheStore: this.cacheStore
             });
 
-            if (returnOperationMetadata) {
-                metadata = this._initMetadata({
-                    requestId: requestId!,
-                    startTime: startTime!,
-                    preparedRequest,
-                    llmOptions,
-                    operationId: resilientOperation.id,
-                });
-                observabilityOptions = { ...observabilityOptions, metadata };
-            }
+            metadata = this._initMetadata({
+                requestId,
+                startTime,
+                preparedRequest,
+                llmOptions,
+                operationId: resilientOperation.id,
+            });
+            observabilityOptions = { ...observabilityOptions, metadata };
 
             if (!this._abortController || this._abortController.signal.aborted) {
                 this._abortController = new AbortController();
@@ -363,12 +369,13 @@ class ResilientLLM {
                 structuredOutputConfig: preparedRequest.structuredOutputConfig,
                 tools: llmOptions?.tools,
             });
-            const normalizedContent = parsedResponse.content;
+            const content = parsedResponse.content;
+            const toolCalls = parsedResponse.toolCalls;
 
-            const effectiveContent = (normalizedContent && typeof normalizedContent === 'object' && 'content' in normalizedContent && 'toolCalls' in normalizedContent)
-                ? (normalizedContent as ChatToolCallResult).content
-                : normalizedContent;
-            const isEmpty = effectiveContent == null || (typeof effectiveContent === 'string' && effectiveContent.trim() === '');
+            // Expose finish semantics to callers via metadata for observability.
+            metadata!.finishReason = parsedResponse.finishReason ?? null;
+
+            const isEmpty = content == null || (typeof content === 'string' && content.trim() === '');
             if (isEmpty) {
                 console.warn("Empty response from LLM");
             }
@@ -381,39 +388,42 @@ class ResilientLLM {
 
             delete this.resilientOperations[resilientOperation.id];
 
-            if (returnOperationMetadata && metadata) {
-                const usageData = data?.usage && typeof data.usage === 'object'
-                    ? (data.usage as Record<string, unknown>)
-                    : {};
-                metadata = this._finalizeMetadata(
-                    metadata,
-                    'success',
-                    resilientOperation.getRuntimeMetrics(),
-                    usageData,
-                );
-                return { content: normalizedContent as string | Record<string, unknown> | ChatToolCallResult | null, metadata } as ChatResponseWithMetadata;
-            }
-            return normalizedContent;
+            const usageData = data?.usage && typeof data.usage === 'object'
+                ? (data.usage as Record<string, unknown>)
+                : {};
+            metadata = this._finalizeMetadata(
+                metadata!,
+                'success',
+                resilientOperation.getRuntimeMetrics(),
+                usageData,
+            );
+
+            const response: ChatResponse = {
+                content: content ?? null,
+                ...(toolCalls !== undefined ? { toolCalls } : {}),
+                metadata,
+            };
+
+            return response;
         } catch (error) {
             const aiService = llmOptions?.aiService || this.aiService;
             console.error(`Error calling ${aiService} API:`, error);
             if (resilientOperation) {
                 delete this.resilientOperations[resilientOperation.id];
             }
-            if (returnOperationMetadata && metadata) {
+            if (metadata) {
                 metadata = this._finalizeMetadata(
                     metadata,
                     'error',
                     resilientOperation?.getRuntimeMetrics() ?? null,
                 );
             }
-            this.parseError(null, error as Error, returnOperationMetadata ? metadata : null);
-            return null; // unreachable since parseError always throws, but satisfies TS
+            this.parseError(null, error as Error, metadata);
         }
     }
 
     /** Resolves resilience settings from instance defaults and per-call overrides. */
-    private _resolveResilienceConfig(llmOptions: LLMOptions): EffectiveResilienceConfig {
+    private _resolveResilienceConfig(llmOptions: LLMOptions): ResilienceConfig {
         return {
             timeout: Number(llmOptions?.timeout ?? this.timeout),
             retries: llmOptions?.retries ?? this.retries,
@@ -585,18 +595,36 @@ class ResilientLLM {
             aiService,
             model,
             maxInputTokens,
-            effectiveResilienceConfig: this._resolveResilienceConfig(llmOptions),
+            resilienceConfig: this._resolveResilienceConfig(llmOptions),
             enableCache: llmOptions?.enableCache ?? true,
         };
     }
 
-    /** Parses and normalizes the provider response into caller-facing content. */
+    /** Parses and normalizes the provider response into caller-facing content.
+     * @param input - The input object containing the raw data, chat configuration, and tools.
+     * @returns The parsed chat response.
+     * @throws {StructuredOutputError} If the structured output parsing or validation fails.
+     * @example
+     * const parsedChatResponse = this._handleResponse({
+     *   rawData: rawProviderResponse,
+     *   chatConfig: chatConfig,
+     *   tools: tools,
+     *   structuredOutputConfig: structuredOutputConfig,
+     * });
+     * // {
+     * //   content: 'The capital of France is Paris.',
+     * //   finishReason: 'stop',
+     * // }
+    */
     private _handleResponse(input: ChatResponseHandlerInput): ParsedChatResponse {
         const envelope = this.parseChatCompletion(input.rawData, input.chatConfig, input.tools);
-        let normalizedContent: string | Record<string, unknown> | ChatToolCallResult | null;
+
+        let content: string | Record<string, unknown> | null = envelope.content ?? null;
+        let toolCalls: unknown | undefined;
 
         if (envelope.toolCalls) {
-            normalizedContent = { content: envelope.content, toolCalls: envelope.toolCalls };
+            // In tool mode, keep assistant payload + tool calls separate.
+            toolCalls = envelope.toolCalls;
         } else if (input.structuredOutputConfig && input.structuredOutputConfig.expectsJson) {
             const parseResult = parseStructuredResponse(envelope, input.structuredOutputConfig);
             if (!parseResult.ok) {
@@ -640,16 +668,15 @@ class ResilientLLM {
                     );
                     throw new StructuredOutputError(validateResult.error);
                 }
-                normalizedContent = validateResult.data;
+                content = validateResult.data;
             } else {
-                normalizedContent = parseResult.data as string | null;
+                content = parseResult.data as string | null;
             }
-        } else {
-            normalizedContent = envelope.content ?? null;
         }
 
         return {
-            content: normalizedContent,
+            content,
+            ...(toolCalls !== undefined ? { toolCalls } : {}),
             finishReason: envelope.finishReason ?? null,
         };
     }
@@ -673,6 +700,7 @@ class ResilientLLM {
             requestId,
             operationId,
             startTime,
+            finishReason: null,
             config: {
                 aiService: preparedRequest.aiService,
                 model: preparedRequest.model,
@@ -682,7 +710,7 @@ class ResilientLLM {
                 maxInputTokens: preparedRequest.maxInputTokens,
                 estimatedInputTokens: preparedRequest.estimatedTokens,
                 enableCache: preparedRequest.enableCache,
-                ...preparedRequest.effectiveResilienceConfig,
+                ...preparedRequest.resilienceConfig,
             },
             events: [],
             timing: { totalTimeMs: null, rateLimitWaitMs: 0, httpRequestMs: null },
@@ -763,7 +791,7 @@ class ResilientLLM {
     async retryChatWithAlternateService(
         conversationHistory: ChatMessage[],
         llmOptions: LLMOptions = {}
-    ): Promise<string | Record<string, unknown> | ChatToolCallResult | ChatResponseWithMetadata | null> {
+    ): Promise<ChatResponse> {
         this.llmOutOfService = this.llmOutOfService || [];
         const currentService = llmOptions?.aiService || this.aiService;
         this.llmOutOfService.push(currentService);

--- a/lib/ResilientLLM.ts
+++ b/lib/ResilientLLM.ts
@@ -16,6 +16,9 @@ import { randomUUID } from "node:crypto";
 import ResilientOperation from "./ResilientOperation.js";
 import ProviderRegistry, { type ChatConfig } from "./ProviderRegistry.js";
 import type { RateLimitConfig } from "./RateLimitManager.js";
+import { StructuredOutput } from "./StructuredOutput.js";
+
+export type { SchemaValidationIssue } from "./StructuredOutput.js";
 
 export interface ChatMessage {
     role: 'system' | 'user' | 'assistant' | 'tool';
@@ -62,6 +65,10 @@ export interface LLMOptions {
     apiKey?: string;
     tools?: ToolDefinition[];
     responseFormat?: unknown;
+    response_format?: unknown;
+    outputConfig?: unknown;
+    output_config?: unknown;
+    parseStructuredOutput?: boolean;
     enableCache?: boolean;
     returnOperationMetadata?: boolean;
 }
@@ -99,7 +106,7 @@ export interface OperationMetadata {
 }
 
 export interface ChatResponseWithMetadata {
-    content: string | ChatToolCallResult | null;
+    content: string | Record<string, unknown> | ChatToolCallResult | null;
     metadata: OperationMetadata;
 }
 
@@ -186,7 +193,7 @@ class ResilientLLM {
         conversationHistory: ChatMessage[],
         llmOptions: LLMOptions = {},
         observabilityOptions: ObservabilityOptions = {}
-    ): Promise<string | ChatToolCallResult | ChatResponseWithMetadata | null> {
+    ): Promise<string | Record<string, unknown> | ChatToolCallResult | ChatResponseWithMetadata | null> {
         // TODO: Support dynamic selection/correction of params (e.g. reasoning vs non-reasoning models);
         const returnOperationMetadata = llmOptions?.returnOperationMetadata ?? this.returnOperationMetadata ?? false;
         const startTime = returnOperationMetadata ? Date.now() : null;
@@ -247,8 +254,21 @@ class ResilientLLM {
         if (llmOptions?.tools) {
             requestBody.tools = llmOptions.tools;
         }
-        if (llmOptions?.responseFormat) {
-            requestBody.response_format = llmOptions.responseFormat;
+        // Accept both JS-style camelCase and HTTP-style snake_case aliases.
+        // StructuredOutput normalizes these and rejects ambiguous duplicates.
+        const structuredOutput = StructuredOutput.fromInputs({
+            responseFormat: llmOptions?.responseFormat,
+            response_format: llmOptions?.response_format,
+            outputConfig: llmOptions?.outputConfig,
+            output_config: llmOptions?.output_config,
+        });
+        const requestField = chatConfig.structuredOutputRequestField || 'response_format';
+        const { responseFormat, outputConfig } = structuredOutput.getRequestFields(requestField);
+        if (responseFormat !== undefined) {
+            requestBody.response_format = responseFormat;
+        }
+        if (outputConfig !== undefined) {
+            requestBody.output_config = outputConfig;
         }
         if (model?.startsWith("o") || model?.startsWith("gpt-5")) {
             // Reasoning model parameters
@@ -400,9 +420,11 @@ class ResilientLLM {
             }
 
             const content = this.parseChatCompletion(data, chatConfig, llmOptions?.tools);
-            const effectiveContent = (content && typeof content === 'object' && 'content' in content)
-                ? (content as ChatToolCallResult).content
-                : content;
+            const shouldParseStructuredOutput = llmOptions?.parseStructuredOutput ?? true;
+            const normalizedContent = shouldParseStructuredOutput ? structuredOutput.parse(content) : content;
+            const effectiveContent = (normalizedContent && typeof normalizedContent === 'object' && 'content' in normalizedContent)
+                ? (normalizedContent as ChatToolCallResult).content
+                : normalizedContent;
             const isEmpty = effectiveContent == null || (typeof effectiveContent === 'string' && effectiveContent.trim() === '');
             if (isEmpty) {
                 console.warn("Empty response from LLM");
@@ -434,9 +456,9 @@ class ResilientLLM {
                     llmOptions,
                 });
 
-                return { content, metadata } as ChatResponseWithMetadata;
+                return { content: normalizedContent as string | Record<string, unknown> | ChatToolCallResult | null, metadata } as ChatResponseWithMetadata;
             }
-            return content;
+            return normalizedContent;
         } catch (error) {
             console.error(`Error calling ${aiService} API:`, error);
             if (returnOperationMetadata && metadata) {
@@ -460,7 +482,7 @@ class ResilientLLM {
     async retryChatWithAlternateService(
         conversationHistory: ChatMessage[],
         llmOptions: LLMOptions = {}
-    ): Promise<string | ChatToolCallResult | ChatResponseWithMetadata | null> {
+    ): Promise<string | Record<string, unknown> | ChatToolCallResult | ChatResponseWithMetadata | null> {
         this.llmOutOfService = this.llmOutOfService || [];
         const currentService = llmOptions?.aiService || this.aiService;
         this.llmOutOfService.push(currentService);
@@ -527,6 +549,9 @@ class ResilientLLM {
         }
     }
 
+    /**
+     * Builds the operation metadata object.
+     */
     private static _buildOperationMetadata(params: {
         base: OperationMetadata | null;
         aiService: string;
@@ -679,6 +704,10 @@ class ResilientLLM {
             default:
                 err = new Error(error?.message || "Unknown error");
         }
+        const passthrough = Object.fromEntries(
+            Object.entries(error as unknown as Record<string, unknown>).filter(([key]) => !['name', 'message', 'stack'].includes(key))
+        );
+        Object.assign(err, passthrough);
         if (operationMetadata) {
             err.metadata = operationMetadata;
         }

--- a/lib/StructuredOutput.ts
+++ b/lib/StructuredOutput.ts
@@ -1,507 +1,505 @@
-/**
- * Describes issues that might arise during validation of a JSON object
- * against a schema. Used for error reporting in structured response handling.
- * 
- * @example
- * {
- *   missingFields: ["id"],
- *   extraFields: ["unexpected"],
- *   typeMismatches: [{ field: "count", expected: "number", actual: "string" }]
- * }
- */
+// ─── Policy Types ────────────────────────────────────────────────────────
+
+export type ParseMode = 'off' | 'best_effort' | 'strict_json';
+export type ValidationMode = 'off' | 'shallow' | 'schema_strict';
+
+// ─── Result Type ─────────────────────────────────────────────────────────
+
+export type StructuredOutputResult<T, E = StructuredOutputErrorInfo> =
+    | { ok: true; data: T }
+    | { ok: false; data?: T; error: E };
+
+// ─── Schema Validation ───────────────────────────────────────────────────
+
 export interface SchemaValidationIssue {
-    missingFields: string[]; // Keys required by the schema, but not present in the object.
-    extraFields: string[];   // Keys present in the object but not allowed by the schema.
+    missingFields: string[];
+    extraFields: string[];
     typeMismatches: Array<{
-        field: string;       // Which field mismatched.
-        expected: string;    // Expected primitive type from schema.
-        actual: string;      // Actual type in provided content.
+        field: string;
+        expected: string;
+        actual: string;
     }>;
 }
 
-/**
- * Configuration for normalization and validation of a structured output
- * (before and after requesting an LLM).
- * 
- * @example
- * {
- *   responseFormat: { type: "json_object" },
- *   outputConfig: { format: ... },
- *   schema: { properties: ... },
- *   expectsJson: true
- * }
- */
-export interface StructuredOutputConfig {
-    responseFormat?: unknown;   // The normalized format definition (if supplied) for LLM output.
-    outputConfig?: unknown;     // Provider-specific "output_config" wrapper, if applicable.
-    schema: Record<string, unknown> | null; // Schema for post-parsing validation (or null).
-    expectsJson: boolean;       // True if the LLM is expected to return a JSON object.
+// ─── Error DTO ───────────────────────────────────────────────────────────
+
+export type StructuredOutputErrorCode =
+    | 'JSON_PARSE_ERROR'
+    | 'JSON_MODE_FAILURE'
+    | 'SCHEMA_MISMATCH';
+
+export interface StructuredOutputErrorInfo {
+    code: StructuredOutputErrorCode;
+    message: string;
+    rawResponse: unknown;
+    validation: SchemaValidationIssue | null;
 }
 
 /**
- * Minimal request fields to include with outbound API requests to LLM providers.
- * Only one of these will be set, based on the provider/wrapper.
- * 
- * @example
- * { responseFormat: { type: 'json_object' } }
- * @example
- * { outputConfig: { format: { type: 'json_schema', ... } } }
+ * Throwable error for structured output failures.
+ * Created at the ResilientLLM.chat() boundary from a Result error DTO.
  */
+export class StructuredOutputError extends Error {
+    code: StructuredOutputErrorCode;
+    rawResponse: unknown;
+    validation: SchemaValidationIssue | null;
+
+    constructor(info: StructuredOutputErrorInfo) {
+        super(info.message);
+        this.name = 'StructuredOutputError';
+        this.code = info.code;
+        this.rawResponse = info.rawResponse;
+        this.validation = info.validation;
+    }
+}
+
+// ─── Normalized Config ───────────────────────────────────────────────────
+
+export interface NormalizedStructuredOutputConfig {
+    expectsJson: boolean;
+    schema: Record<string, unknown> | null;
+    schemaName: string;
+    parseMode: ParseMode;
+    validationMode: ValidationMode;
+    /** Preserved original output_config for migration passthrough. */
+    _outputConfig?: unknown;
+    _source: 'responseFormat' | 'output_config' | 'none';
+}
+
+// ─── Request Fields ──────────────────────────────────────────────────────
+
 export interface StructuredRequestFields {
-    responseFormat?: unknown;
-    outputConfig?: unknown;
-}
-
-/**
- * All ways a caller may request structured outputs (configurable by client).
- * Accepts both camelCase and snake_case keys, and optionally wrappers.
- * 
- * @example
- * { responseFormat: { type: "json_object" } }
- * @example
- * { response_format: { type: "json_object" } }
- * @example
- * { outputConfig: { format: ... } }
- * @example
- * { output_config: { format: ... } }
- */
-export interface StructuredOutputOptions {
-    responseFormat?: unknown;
     response_format?: unknown;
-    outputConfig?: unknown;
     output_config?: unknown;
 }
 
-/**
- * Return value when content was produced by a tool call, not as plain JSON or text.
- * Used for forwarding LLM tool results through the structured output interface.
- * 
- * @example
- * {
- *   content: null,
- *   toolCalls: [...]
- * }
- */
-export interface StructuredToolCallResult {
+// ─── Response Envelope ───────────────────────────────────────────────────
+
+export interface ResponseEnvelope {
     content: string | null;
-    toolCalls: unknown;
+    toolCalls?: unknown;
+    finishReason?: string | null;
 }
 
-/**
- * Acceptable parsed content output from an LLM (normalized or raw).
- * - Can be a string (unstructured text output)
- * - a parsed JSON object
- * - a structured tool call result object
- * - or null
- * 
- * @example
- * 'This is just a string'
- * @example
- * { name: "foo", value: 2 }
- * @example
- * { content: null, toolCalls: [...] }
- */
-export type StructuredContent = string | Record<string, unknown> | StructuredToolCallResult | null;
+// ─── Structured Content ──────────────────────────────────────────────────
+
+export type StructuredContent =
+    | string
+    | Record<string, unknown>
+    | ResponseEnvelope
+    | null;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. NORMALIZE
+// ═══════════════════════════════════════════════════════════════════════════
+
+const CONFIG_DEFAULTS: NormalizedStructuredOutputConfig = {
+    expectsJson: false,
+    schema: null,
+    schemaName: 'structured_response',
+    parseMode: 'off',
+    validationMode: 'off',
+    _source: 'none',
+};
 
 /**
- * Custom error type for all structured output handling errors (e.g. parse, mismatch).
- * Contains the underlying erroneous response and optional schema validation issues.
- * 
+ * Normalizes caller-provided structured output options into a canonical config.
+ *
+ * @param responseFormat - Recommended public input (string alias, object, or schema).
+ * @param outputConfigMigration - Migration input for callers transitioning from provider-native APIs.
+ *   When both are provided, responseFormat takes precedence.
  * @example
- * throw new StructuredOutputError('SCHEMA_MISMATCH', 'Fields missing', '{"foo":1}', { missingFields: ["bar"], ... })
+ * const result = normalizeStructuredOutputConfig("json", );
+ * // result = { ok: true, data: NormalizedStructuredOutputConfig }
  */
-class StructuredOutputError extends Error {
-    code: 'JSON_PARSE_ERROR' | 'JSON_MODE_FAILURE' | 'SCHEMA_MISMATCH'; // Type of failure.
-    rawResponse: unknown;         // The raw offending content.
-    validation: SchemaValidationIssue | null; // Optional validation explanation.
-
-    constructor(
-        code: 'JSON_PARSE_ERROR' | 'JSON_MODE_FAILURE' | 'SCHEMA_MISMATCH',
-        message: string,
-        rawResponse: unknown,
-        validation: SchemaValidationIssue | null = null,
-    ) {
-        super(message);
-        this.name = 'StructuredOutputError';
-        this.code = code;
-        this.rawResponse = rawResponse;
-        this.validation = validation;
+export function normalizeStructuredOutputConfig(
+    responseFormat?: unknown,
+    outputConfigMigration?: unknown,
+): StructuredOutputResult<NormalizedStructuredOutputConfig> {
+    if (responseFormat === undefined && outputConfigMigration === undefined) {
+        return { ok: true, data: CONFIG_DEFAULTS };
     }
+
+    if (outputConfigMigration !== undefined && responseFormat === undefined) {
+        return normalizeFromOutputConfig(outputConfigMigration);
+    }
+
+    if (typeof responseFormat === 'string') {
+        return normalizeFromStringAlias(responseFormat);
+    }
+
+    if (responseFormat && typeof responseFormat === 'object' && !Array.isArray(responseFormat)) {
+        return normalizeFromObjectFormat(responseFormat as Record<string, unknown>);
+    }
+
+    return { ok: true, data: CONFIG_DEFAULTS };
 }
 
-/**
- * StructuredOutput is responsible for managing "format" and schema 
- * normalization for LLM API calls, and for parsing and validating 
- * returned output against schemas as needed.
- * 
- * Usage Example:
- * ```
- * const structured = StructuredOutput.fromInputs({ responseFormat: { type: "json_object" } });
- * const requestFields = structured.getRequestFields();
- * // Make API call...
- * const parsed = structured.parse(apiResponse);
- * ```
- */
-export class StructuredOutput {
-    readonly config: StructuredOutputConfig;
-    private readonly source: StructuredOutputOptions;
-
-    /**
-     * Constructor is private—use StructuredOutput.fromInputs.
-     * @param config Normalized config about how to structure requests and parse outputs.
-     * @param source The original request options the user provided.
-     */
-    private constructor(config: StructuredOutputConfig, source: StructuredOutputOptions = {}) {
-        this.config = config;
-        this.source = source;
-    }
-
-    /**
-     * Create a StructuredOutput from user/caller input.
-     * Handles normalization and aliasing of possible config fields.
-     * 
-     * @param inputs Possibly ambiguous or aliased structured output options.
-     * @returns StructuredOutput instance with normalized representation.
-     * @example
-     * StructuredOutput.fromInputs({ responseFormat: { type: "json_object" } })
-     */
-    static fromInputs(inputs: StructuredOutputOptions): StructuredOutput {
-        StructuredOutput.assertNoAliasConflicts(inputs);
-        // Accept camelCase and snake_case caller keys, including wrapper objects.
-        const resolvedResponseFormat = StructuredOutput.resolveResponseFormatOption(
-            inputs.responseFormat,
-            inputs.response_format
-        );
-        const resolvedOutputConfig = StructuredOutput.resolveOutputConfigOption(
-            inputs.responseFormat,
-            inputs.response_format,
-            inputs.outputConfig,
-            inputs.output_config
-        );
-
-        if (typeof resolvedResponseFormat === 'string') {
-            const normalized = resolvedResponseFormat.trim().toLowerCase();
-            if (normalized === 'json' || normalized === 'object' || normalized === 'json_object') {
-                return new StructuredOutput(
-                    { responseFormat: { type: 'json_object' }, schema: null, expectsJson: true },
-                    { responseFormat: { type: 'json_object' } }
-                );
-            }
-            return new StructuredOutput({ schema: null, expectsJson: false }, { responseFormat: resolvedResponseFormat });
-        }
-
-        if (resolvedOutputConfig && typeof resolvedOutputConfig === 'object' && !Array.isArray(resolvedOutputConfig)) {
-            const outputConfig = resolvedOutputConfig as Record<string, unknown>;
-            const format = (outputConfig.format && typeof outputConfig.format === 'object' && !Array.isArray(outputConfig.format))
-                ? outputConfig.format as Record<string, unknown>
-                : null;
-            const schema = format ? StructuredOutput.extractJsonSchema(format) : null;
-            const expectsJson = format?.type === 'json_schema' || schema !== null;
-            return new StructuredOutput(
-                { outputConfig, schema, expectsJson },
-                { outputConfig }
-            );
-        }
-
-        if (!resolvedResponseFormat || typeof resolvedResponseFormat !== 'object' || Array.isArray(resolvedResponseFormat)) {
-            return new StructuredOutput({ schema: null, expectsJson: false }, {});
-        }
-
-        const format = resolvedResponseFormat as Record<string, unknown>;
-        if (format.type === 'json_object') {
-            return new StructuredOutput({ responseFormat: format, schema: null, expectsJson: true }, { responseFormat: format });
-        }
-
-        const schema = StructuredOutput.extractJsonSchema(format);
-        if (!schema) {
-            return new StructuredOutput({
-                responseFormat: format,
-                schema: null,
-                expectsJson: false,
-            }, { responseFormat: format });
-        }
-
-        return new StructuredOutput({
-            responseFormat: format,
-            schema,
-            expectsJson: true,
-        }, { responseFormat: format });
-    }
-
-    getRequestFields(requestField: 'response_format' | 'output_config' = 'response_format'): StructuredRequestFields {
-        if (requestField === 'output_config') {
-            if (this.source.outputConfig !== undefined) {
-                return { outputConfig: this.source.outputConfig };
-            }
-            const derivedOutputConfig = this.deriveOutputConfig();
-            return derivedOutputConfig !== undefined ? { outputConfig: derivedOutputConfig } : {};
-        }
-
-        if (this.source.responseFormat !== undefined) {
-            return { responseFormat: this.source.responseFormat };
-        }
-        const derivedResponseFormat = this.deriveResponseFormat();
-        return derivedResponseFormat !== undefined ? { responseFormat: derivedResponseFormat } : {};
-    }
-
-    parse(content: StructuredContent): StructuredContent {
-        if (!this.config.expectsJson) return content;
-        if (StructuredOutput.isToolCallResult(content)) return content;
-
-        const validated = (obj: Record<string, unknown>, raw: unknown): Record<string, unknown> => {
-            if (!this.config.schema) return obj;
-            const issues = StructuredOutput.validateAgainstSchema(obj, this.config.schema);
-            if (issues) {
-                throw new StructuredOutputError(
-                    'SCHEMA_MISMATCH',
-                    'Schema mismatch: response JSON does not match required fields/types',
-                    raw,
-                    issues
-                );
-            }
-            return obj;
+function normalizeFromStringAlias(
+    alias: string,
+): StructuredOutputResult<NormalizedStructuredOutputConfig> {
+    const normalized = alias.trim().toLowerCase();
+    if (normalized === 'json' || normalized === 'object' || normalized === 'json_object') {
+        return {
+            ok: true,
+            data: {
+                ...CONFIG_DEFAULTS,
+                expectsJson: true,
+                parseMode: 'best_effort',
+                _source: 'responseFormat',
+            },
         };
+    }
+    return { ok: true, data: { ...CONFIG_DEFAULTS, _source: 'responseFormat' } };
+}
 
-        if (content && typeof content === 'object') {
-            if (Array.isArray(content)) {
-                throw new StructuredOutputError('JSON_MODE_FAILURE', 'JSON response must be an object', content);
+function normalizeFromObjectFormat(
+    format: Record<string, unknown>,
+): StructuredOutputResult<NormalizedStructuredOutputConfig> {
+    const userParseMode = typeof format.parse === 'string'
+        ? format.parse as ParseMode
+        : undefined;
+    const userValidateMode = typeof format.validate === 'string'
+        ? format.validate as ValidationMode
+        : undefined;
+
+    if (format.type === 'json_object') {
+        return {
+            ok: true,
+            data: {
+                ...CONFIG_DEFAULTS,
+                expectsJson: true,
+                parseMode: userParseMode ?? 'best_effort',
+                validationMode: userValidateMode ?? 'off',
+                _source: 'responseFormat',
+            },
+        };
+    }
+
+    const schema = extractJsonSchema(format);
+    if (schema || format.type === 'json_schema') {
+        return {
+            ok: true,
+            data: {
+                ...CONFIG_DEFAULTS,
+                expectsJson: true,
+                schema,
+                schemaName: (format.schemaName as string)
+                    || (format.name as string)
+                    || extractSchemaName(format)
+                    || CONFIG_DEFAULTS.schemaName,
+                parseMode: userParseMode ?? 'best_effort',
+                validationMode: userValidateMode ?? (schema ? 'shallow' : 'off'),
+                _source: 'responseFormat',
+            },
+        };
+    }
+
+    // Bare schema object passed directly (has properties or required)
+    if ('properties' in format || 'required' in format) {
+        return {
+            ok: true,
+            data: {
+                ...CONFIG_DEFAULTS,
+                expectsJson: true,
+                schema: format,
+                parseMode: userParseMode ?? 'best_effort',
+                validationMode: userValidateMode ?? 'shallow',
+                _source: 'responseFormat',
+            },
+        };
+    }
+
+    return {
+        ok: true,
+        data: {
+            ...CONFIG_DEFAULTS,
+            parseMode: userParseMode ?? 'off',
+            validationMode: userValidateMode ?? 'off',
+            _source: 'responseFormat',
+        },
+    };
+}
+
+function normalizeFromOutputConfig(
+    outputConfig: unknown,
+): StructuredOutputResult<NormalizedStructuredOutputConfig> {
+    if (typeof outputConfig !== 'object' || outputConfig === null || Array.isArray(outputConfig)) {
+        return {
+            ok: true,
+            data: { ...CONFIG_DEFAULTS, _outputConfig: outputConfig, _source: 'output_config' },
+        };
+    }
+
+    const oc = outputConfig as Record<string, unknown>;
+    const format = (oc.format && typeof oc.format === 'object' && !Array.isArray(oc.format))
+        ? oc.format as Record<string, unknown>
+        : null;
+    const schema = format ? extractJsonSchema(format) : null;
+    const expectsJson = format?.type === 'json_schema' || schema !== null;
+
+    return {
+        ok: true,
+        data: {
+            ...CONFIG_DEFAULTS,
+            expectsJson,
+            schema,
+            parseMode: expectsJson ? 'best_effort' : 'off',
+            validationMode: schema ? 'shallow' : 'off',
+            _outputConfig: outputConfig,
+            _source: 'output_config',
+        },
+    };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. MAP TO PROVIDER REQUEST FIELDS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Maps a normalized config to provider-native request body fields.
+ *
+ * @param config - Canonical structured output config from normalizeStructuredOutputConfig.
+ * @param requestField - Which provider field to target (from ProviderRegistry chatConfig).
+ */
+export function mapConfigToRequestFields(
+    config: NormalizedStructuredOutputConfig,
+    requestField: 'response_format' | 'output_config',
+): StructuredRequestFields {
+    if (config._source === 'none') return {};
+
+    if (requestField === 'output_config') {
+        if (config._outputConfig !== undefined) {
+            return { output_config: config._outputConfig };
+        }
+        return deriveOutputConfig(config);
+    }
+
+    return deriveResponseFormat(config);
+}
+
+function deriveOutputConfig(config: NormalizedStructuredOutputConfig): StructuredRequestFields {
+    // json_object mode without schema: Anthropic doesn't support this natively.
+    // Rely on best-effort post-parsing instead.
+    if (config.expectsJson && !config.schema) {
+        return {};
+    }
+    if (config.schema) {
+        return {
+            output_config: { format: { type: 'json_schema', schema: config.schema } },
+        };
+    }
+    return {};
+}
+
+function deriveResponseFormat(config: NormalizedStructuredOutputConfig): StructuredRequestFields {
+    if (config.expectsJson && !config.schema) {
+        return { response_format: { type: 'json_object' } };
+    }
+    if (config.schema) {
+        return {
+            response_format: {
+                type: 'json_schema',
+                json_schema: { name: config.schemaName, schema: config.schema },
+            },
+        };
+    }
+    return {};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. PARSE
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Parses a response envelope into structured content.
+ * Tool-call envelopes pass through unchanged.
+ * JSON content is extracted from raw strings, including markdown-fenced blocks.
+ */
+export function parseStructuredResponse(
+    envelope: ResponseEnvelope,
+    config: NormalizedStructuredOutputConfig,
+): StructuredOutputResult<StructuredContent> {
+    if (envelope.toolCalls) {
+        return { ok: true, data: envelope };
+    }
+
+    if (!config.expectsJson || config.parseMode === 'off') {
+        return { ok: true, data: envelope.content };
+    }
+
+    const content = envelope.content;
+    if (typeof content !== 'string' || !content.trim()) {
+        return { ok: true, data: content };
+    }
+
+    const candidates = buildJsonParseCandidates(content);
+    for (const candidate of candidates) {
+        try {
+            const parsed = JSON.parse(candidate);
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                return { ok: true, data: parsed as Record<string, unknown> };
             }
-            return validated(content as Record<string, unknown>, content);
-        }
-
-        if (typeof content === 'string') {
-            const parsed = StructuredOutput.normalizeJsonContent(content);
-            return validated(parsed, content);
-        }
-
-        return content;
-    }
-
-    // Backward-compatible internal alias.
-    normalize(content: StructuredContent): StructuredContent {
-        return this.parse(content);
-    }
-
-    private static extractJsonSchema(format: Record<string, unknown>): Record<string, unknown> | null {
-        if (format.type === 'json_schema' && 'json_schema' in format) {
-            const wrapper = format.json_schema as Record<string, unknown> | undefined;
-            if (wrapper?.schema && typeof wrapper.schema === 'object' && !Array.isArray(wrapper.schema)) {
-                return wrapper.schema as Record<string, unknown>;
-            }
-        }
-        if (format.type === 'json_schema' && format.schema && typeof format.schema === 'object' && !Array.isArray(format.schema)) {
-            return format.schema as Record<string, unknown>;
-        }
-        if (format.type === 'object' || 'properties' in format || 'required' in format) {
-            return format;
-        }
-        if (format.schema && typeof format.schema === 'object' && !Array.isArray(format.schema)) {
-            return format.schema as Record<string, unknown>;
-        }
-        return null;
-    }
-
-    private static assertNoAliasConflicts(inputs: StructuredOutputOptions): void {
-        if (inputs.responseFormat !== undefined && inputs.response_format !== undefined) {
-            throw new Error('Provide either "responseFormat" or "response_format", not both.');
-        }
-        if (inputs.outputConfig !== undefined && inputs.output_config !== undefined) {
-            throw new Error('Provide either "outputConfig" or "output_config", not both.');
-        }
-    }
-
-    private static resolveResponseFormatOption(responseFormat: unknown, responseFormatAlias: unknown): unknown {
-        if (responseFormatAlias !== undefined) {
-            return responseFormatAlias;
-        }
-        if (responseFormat && typeof responseFormat === 'object' && !Array.isArray(responseFormat)) {
-            const maybeWrapper = responseFormat as Record<string, unknown>;
-            if (maybeWrapper.responseFormat !== undefined) {
-                return maybeWrapper.responseFormat;
-            }
-            if (maybeWrapper.response_format !== undefined) {
-                return maybeWrapper.response_format;
-            }
-        }
-        return responseFormat;
-    }
-
-    private static resolveOutputConfigOption(
-        responseFormat: unknown,
-        responseFormatAlias: unknown,
-        outputConfig: unknown,
-        outputConfigAlias: unknown
-    ): unknown {
-        if (outputConfig !== undefined) {
-            return outputConfig;
-        }
-        if (outputConfigAlias !== undefined) {
-            return outputConfigAlias;
-        }
-        const wrappers = [responseFormat, responseFormatAlias];
-        for (const wrapper of wrappers) {
-            if (wrapper && typeof wrapper === 'object' && !Array.isArray(wrapper)) {
-                const maybeWrapper = wrapper as Record<string, unknown>;
-                if (maybeWrapper.outputConfig !== undefined) {
-                    return maybeWrapper.outputConfig;
-                }
-                if (maybeWrapper.output_config !== undefined) {
-                    return maybeWrapper.output_config;
-                }
-            }
-        }
-        return undefined;
-    }
-
-    private isJsonObjectFormat(value: unknown): boolean {
-        return !!value
-            && typeof value === 'object'
-            && !Array.isArray(value)
-            && (value as Record<string, unknown>).type === 'json_object';
-    }
-
-    private deriveOutputConfig(): unknown {
-        if (this.config.outputConfig !== undefined) {
-            return this.config.outputConfig;
-        }
-
-        if (this.config.responseFormat && this.isJsonObjectFormat(this.config.responseFormat)) {
-            // No user-provided schema: do not invent a restrictive schema.
-            // Providers that require schema-based structured config should receive no
-            // structured request field here and rely on best-effort post parsing.
-            return undefined;
-        }
-
-        if (this.config.schema) {
-            return { format: { type: 'json_schema', schema: this.config.schema } };
-        }
-
-        return undefined;
-    }
-
-    private deriveResponseFormat(): unknown {
-        if (this.config.responseFormat !== undefined) {
-            return this.config.responseFormat;
-        }
-
-        if (this.source.outputConfig && typeof this.source.outputConfig === 'object' && !Array.isArray(this.source.outputConfig)) {
-            const outputConfig = this.source.outputConfig as Record<string, unknown>;
-            const format = (outputConfig.format && typeof outputConfig.format === 'object' && !Array.isArray(outputConfig.format))
-                ? outputConfig.format as Record<string, unknown>
-                : null;
-
-            if (format?.type === 'json_object') {
-                return { type: 'json_object' };
-            }
-            if (format?.type === 'json_schema' && format.schema && typeof format.schema === 'object' && !Array.isArray(format.schema)) {
+            if (Array.isArray(parsed)) {
                 return {
-                    type: 'json_schema',
-                    json_schema: { name: 'structured_response', schema: format.schema },
+                    ok: false,
+                    error: {
+                        code: 'JSON_MODE_FAILURE',
+                        message: 'JSON response must be an object',
+                        rawResponse: content,
+                        validation: null,
+                    },
                 };
             }
+        } catch {
+            // try next candidate
         }
-
-        if (this.config.schema) {
-            return {
-                type: 'json_schema',
-                json_schema: { name: 'structured_response', schema: this.config.schema },
-            };
-        }
-
-        return undefined;
     }
 
-    private static normalizeJsonContent(content: string): Record<string, unknown> {
-        let parsed: unknown = null;
-        const candidates = StructuredOutput.buildJsonParseCandidates(content);
-        for (const candidate of candidates) {
-            try {
-                parsed = JSON.parse(candidate);
-                break;
-            } catch {
-                // Try next parse candidate.
-            }
-        }
-        if (parsed === null) {
-            throw new StructuredOutputError('JSON_PARSE_ERROR', 'JSON parse failed for structured response', content);
-        }
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-            throw new StructuredOutputError('JSON_MODE_FAILURE', 'JSON response must be an object', content);
-        }
-        return parsed as Record<string, unknown>;
-    }
-
-    private static buildJsonParseCandidates(content: string): string[] {
-        const candidates: string[] = [];
-        const trimmed = content.trim();
-        if (!trimmed) return candidates;
-
-        candidates.push(trimmed);
-
-        // Common LLM output shape: fenced markdown JSON block.
-        const fullFenceMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
-        if (fullFenceMatch?.[1]) {
-            candidates.push(fullFenceMatch[1].trim());
-        }
-
-        // Fallback: first fenced block embedded in additional prose.
-        const embeddedFenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
-        if (embeddedFenceMatch?.[1]) {
-            candidates.push(embeddedFenceMatch[1].trim());
-        }
-
-        return Array.from(new Set(candidates));
-    }
-
-    private static validateAgainstSchema(data: Record<string, unknown>, schema: Record<string, unknown>): SchemaValidationIssue | null {
-        const required = Array.isArray(schema.required)
-            ? schema.required.filter((r): r is string => typeof r === 'string')
-            : [];
-        const properties = (schema.properties && typeof schema.properties === 'object')
-            ? schema.properties as Record<string, Record<string, unknown>>
-            : {};
-
-        const missingFields = required.filter(field => !(field in data));
-        const extraFields = (schema.additionalProperties === false && Object.keys(properties).length > 0)
-            ? Object.keys(data).filter(key => !(key in properties))
-            : [];
-
-        const typeMismatches: SchemaValidationIssue['typeMismatches'] = [];
-        for (const [field, fieldSchema] of Object.entries(properties)) {
-            if (!(field in data) || !fieldSchema || typeof fieldSchema !== 'object') continue;
-            const expected = StructuredOutput.schemaPrimitiveType(fieldSchema);
-            if (!expected) continue;
-            const actual = StructuredOutput.runtimePrimitiveType(data[field]);
-            if (actual !== expected && !(expected === 'number' && actual === 'integer')) {
-                typeMismatches.push({ field, expected, actual });
-            }
-        }
-
-        if (missingFields.length === 0 && extraFields.length === 0 && typeMismatches.length === 0) {
-            return null;
-        }
-        return { missingFields, extraFields, typeMismatches };
-    }
-
-    private static schemaPrimitiveType(fieldSchema: Record<string, unknown>): string | null {
-        const t = fieldSchema.type;
-        const resolved = Array.isArray(t) ? t[0] : t;
-        return (resolved === 'string' || resolved === 'number' || resolved === 'boolean' || resolved === 'integer')
-            ? resolved as string
-            : null;
-    }
-
-    private static runtimePrimitiveType(value: unknown): string {
-        if (typeof value === 'string') return 'string';
-        if (typeof value === 'boolean') return 'boolean';
-        if (typeof value === 'number') return Number.isInteger(value) ? 'integer' : 'number';
-        if (value === null) return 'null';
-        if (Array.isArray(value)) return 'array';
-        if (typeof value === 'object') return 'object';
-        return typeof value;
-    }
-
-    private static isToolCallResult(value: unknown): value is StructuredToolCallResult {
-        return !!value && typeof value === 'object' && 'toolCalls' in value;
-    }
+    return {
+        ok: false,
+        error: {
+            code: 'JSON_PARSE_ERROR',
+            message: 'JSON parse failed for structured response',
+            rawResponse: content,
+            validation: null,
+        },
+    };
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. VALIDATE
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Validates a parsed JSON object against the expected schema from the normalized config.
+ * Returns the object unchanged on success, or an error DTO on mismatch.
+ */
+export function validateStructuredResponse(
+    parsedContent: Record<string, unknown>,
+    config: NormalizedStructuredOutputConfig,
+): StructuredOutputResult<Record<string, unknown>> {
+    if (config.validationMode === 'off' || !config.schema) {
+        return { ok: true, data: parsedContent };
+    }
+
+    const issues = validateAgainstSchema(parsedContent, config.schema);
+    if (!issues) {
+        return { ok: true, data: parsedContent };
+    }
+
+    return {
+        ok: false,
+        data: parsedContent,
+        error: {
+            code: 'SCHEMA_MISMATCH',
+            message: 'Schema mismatch: response JSON does not match required fields/types',
+            rawResponse: parsedContent,
+            validation: issues,
+        },
+    };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HELPERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+function extractJsonSchema(format: Record<string, unknown>): Record<string, unknown> | null {
+    if (format.type === 'json_schema' && 'json_schema' in format) {
+        const wrapper = format.json_schema as Record<string, unknown> | undefined;
+        if (wrapper?.schema && typeof wrapper.schema === 'object' && !Array.isArray(wrapper.schema)) {
+            return wrapper.schema as Record<string, unknown>;
+        }
+    }
+    if (format.type === 'json_schema' && format.schema && typeof format.schema === 'object' && !Array.isArray(format.schema)) {
+        return format.schema as Record<string, unknown>;
+    }
+    if (format.schema && typeof format.schema === 'object' && !Array.isArray(format.schema)) {
+        return format.schema as Record<string, unknown>;
+    }
+    return null;
+}
+
+function extractSchemaName(format: Record<string, unknown>): string | null {
+    if (format.json_schema && typeof format.json_schema === 'object') {
+        const wrapper = format.json_schema as Record<string, unknown>;
+        if (typeof wrapper.name === 'string') return wrapper.name;
+    }
+    return null;
+}
+
+function buildJsonParseCandidates(content: string): string[] {
+    const candidates: string[] = [];
+    const trimmed = content.trim();
+    if (!trimmed) return candidates;
+
+    candidates.push(trimmed);
+
+    const fullFenceMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+    if (fullFenceMatch?.[1]) {
+        candidates.push(fullFenceMatch[1].trim());
+    }
+
+    const embeddedFenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+    if (embeddedFenceMatch?.[1]) {
+        candidates.push(embeddedFenceMatch[1].trim());
+    }
+
+    return Array.from(new Set(candidates));
+}
+
+function validateAgainstSchema(
+    data: Record<string, unknown>,
+    schema: Record<string, unknown>,
+): SchemaValidationIssue | null {
+    const required = Array.isArray(schema.required)
+        ? schema.required.filter((r): r is string => typeof r === 'string')
+        : [];
+    const properties = (schema.properties && typeof schema.properties === 'object')
+        ? schema.properties as Record<string, Record<string, unknown>>
+        : {};
+
+    const missingFields = required.filter(field => !(field in data));
+    const extraFields = (schema.additionalProperties === false && Object.keys(properties).length > 0)
+        ? Object.keys(data).filter(key => !(key in properties))
+        : [];
+
+    const typeMismatches: SchemaValidationIssue['typeMismatches'] = [];
+    for (const [field, fieldSchema] of Object.entries(properties)) {
+        if (!(field in data) || !fieldSchema || typeof fieldSchema !== 'object') continue;
+        const expected = schemaPrimitiveType(fieldSchema);
+        if (!expected) continue;
+        const actual = runtimePrimitiveType(data[field]);
+        if (actual !== expected && !(expected === 'number' && actual === 'integer')) {
+            typeMismatches.push({ field, expected, actual });
+        }
+    }
+
+    if (missingFields.length === 0 && extraFields.length === 0 && typeMismatches.length === 0) {
+        return null;
+    }
+    return { missingFields, extraFields, typeMismatches };
+}
+
+function schemaPrimitiveType(fieldSchema: Record<string, unknown>): string | null {
+    const t = fieldSchema.type;
+    const resolved = Array.isArray(t) ? t[0] : t;
+    return (resolved === 'string' || resolved === 'number' || resolved === 'boolean' || resolved === 'integer')
+        ? resolved as string
+        : null;
+}
+
+function runtimePrimitiveType(value: unknown): string {
+    if (typeof value === 'string') return 'string';
+    if (typeof value === 'boolean') return 'boolean';
+    if (typeof value === 'number') return Number.isInteger(value) ? 'integer' : 'number';
+    if (value === null) return 'null';
+    if (Array.isArray(value)) return 'array';
+    if (typeof value === 'object') return 'object';
+    return typeof value;
+}
+
+// ─── Follow-up Placeholders ──────────────────────────────────────────────
+// TODO: Parse provenance metadata (native_json vs best_effort) in output/metadata
+// TODO: Policy default tuning and explicit default matrix
+// TODO: Zod support strategy evaluation (no hard dependency): design options, tradeoffs, implementation decision

--- a/lib/StructuredOutput.ts
+++ b/lib/StructuredOutput.ts
@@ -1,0 +1,507 @@
+/**
+ * Describes issues that might arise during validation of a JSON object
+ * against a schema. Used for error reporting in structured response handling.
+ * 
+ * @example
+ * {
+ *   missingFields: ["id"],
+ *   extraFields: ["unexpected"],
+ *   typeMismatches: [{ field: "count", expected: "number", actual: "string" }]
+ * }
+ */
+export interface SchemaValidationIssue {
+    missingFields: string[]; // Keys required by the schema, but not present in the object.
+    extraFields: string[];   // Keys present in the object but not allowed by the schema.
+    typeMismatches: Array<{
+        field: string;       // Which field mismatched.
+        expected: string;    // Expected primitive type from schema.
+        actual: string;      // Actual type in provided content.
+    }>;
+}
+
+/**
+ * Configuration for normalization and validation of a structured output
+ * (before and after requesting an LLM).
+ * 
+ * @example
+ * {
+ *   responseFormat: { type: "json_object" },
+ *   outputConfig: { format: ... },
+ *   schema: { properties: ... },
+ *   expectsJson: true
+ * }
+ */
+export interface StructuredOutputConfig {
+    responseFormat?: unknown;   // The normalized format definition (if supplied) for LLM output.
+    outputConfig?: unknown;     // Provider-specific "output_config" wrapper, if applicable.
+    schema: Record<string, unknown> | null; // Schema for post-parsing validation (or null).
+    expectsJson: boolean;       // True if the LLM is expected to return a JSON object.
+}
+
+/**
+ * Minimal request fields to include with outbound API requests to LLM providers.
+ * Only one of these will be set, based on the provider/wrapper.
+ * 
+ * @example
+ * { responseFormat: { type: 'json_object' } }
+ * @example
+ * { outputConfig: { format: { type: 'json_schema', ... } } }
+ */
+export interface StructuredRequestFields {
+    responseFormat?: unknown;
+    outputConfig?: unknown;
+}
+
+/**
+ * All ways a caller may request structured outputs (configurable by client).
+ * Accepts both camelCase and snake_case keys, and optionally wrappers.
+ * 
+ * @example
+ * { responseFormat: { type: "json_object" } }
+ * @example
+ * { response_format: { type: "json_object" } }
+ * @example
+ * { outputConfig: { format: ... } }
+ * @example
+ * { output_config: { format: ... } }
+ */
+export interface StructuredOutputOptions {
+    responseFormat?: unknown;
+    response_format?: unknown;
+    outputConfig?: unknown;
+    output_config?: unknown;
+}
+
+/**
+ * Return value when content was produced by a tool call, not as plain JSON or text.
+ * Used for forwarding LLM tool results through the structured output interface.
+ * 
+ * @example
+ * {
+ *   content: null,
+ *   toolCalls: [...]
+ * }
+ */
+export interface StructuredToolCallResult {
+    content: string | null;
+    toolCalls: unknown;
+}
+
+/**
+ * Acceptable parsed content output from an LLM (normalized or raw).
+ * - Can be a string (unstructured text output)
+ * - a parsed JSON object
+ * - a structured tool call result object
+ * - or null
+ * 
+ * @example
+ * 'This is just a string'
+ * @example
+ * { name: "foo", value: 2 }
+ * @example
+ * { content: null, toolCalls: [...] }
+ */
+export type StructuredContent = string | Record<string, unknown> | StructuredToolCallResult | null;
+
+/**
+ * Custom error type for all structured output handling errors (e.g. parse, mismatch).
+ * Contains the underlying erroneous response and optional schema validation issues.
+ * 
+ * @example
+ * throw new StructuredOutputError('SCHEMA_MISMATCH', 'Fields missing', '{"foo":1}', { missingFields: ["bar"], ... })
+ */
+class StructuredOutputError extends Error {
+    code: 'JSON_PARSE_ERROR' | 'JSON_MODE_FAILURE' | 'SCHEMA_MISMATCH'; // Type of failure.
+    rawResponse: unknown;         // The raw offending content.
+    validation: SchemaValidationIssue | null; // Optional validation explanation.
+
+    constructor(
+        code: 'JSON_PARSE_ERROR' | 'JSON_MODE_FAILURE' | 'SCHEMA_MISMATCH',
+        message: string,
+        rawResponse: unknown,
+        validation: SchemaValidationIssue | null = null,
+    ) {
+        super(message);
+        this.name = 'StructuredOutputError';
+        this.code = code;
+        this.rawResponse = rawResponse;
+        this.validation = validation;
+    }
+}
+
+/**
+ * StructuredOutput is responsible for managing "format" and schema 
+ * normalization for LLM API calls, and for parsing and validating 
+ * returned output against schemas as needed.
+ * 
+ * Usage Example:
+ * ```
+ * const structured = StructuredOutput.fromInputs({ responseFormat: { type: "json_object" } });
+ * const requestFields = structured.getRequestFields();
+ * // Make API call...
+ * const parsed = structured.parse(apiResponse);
+ * ```
+ */
+export class StructuredOutput {
+    readonly config: StructuredOutputConfig;
+    private readonly source: StructuredOutputOptions;
+
+    /**
+     * Constructor is private—use StructuredOutput.fromInputs.
+     * @param config Normalized config about how to structure requests and parse outputs.
+     * @param source The original request options the user provided.
+     */
+    private constructor(config: StructuredOutputConfig, source: StructuredOutputOptions = {}) {
+        this.config = config;
+        this.source = source;
+    }
+
+    /**
+     * Create a StructuredOutput from user/caller input.
+     * Handles normalization and aliasing of possible config fields.
+     * 
+     * @param inputs Possibly ambiguous or aliased structured output options.
+     * @returns StructuredOutput instance with normalized representation.
+     * @example
+     * StructuredOutput.fromInputs({ responseFormat: { type: "json_object" } })
+     */
+    static fromInputs(inputs: StructuredOutputOptions): StructuredOutput {
+        StructuredOutput.assertNoAliasConflicts(inputs);
+        // Accept camelCase and snake_case caller keys, including wrapper objects.
+        const resolvedResponseFormat = StructuredOutput.resolveResponseFormatOption(
+            inputs.responseFormat,
+            inputs.response_format
+        );
+        const resolvedOutputConfig = StructuredOutput.resolveOutputConfigOption(
+            inputs.responseFormat,
+            inputs.response_format,
+            inputs.outputConfig,
+            inputs.output_config
+        );
+
+        if (typeof resolvedResponseFormat === 'string') {
+            const normalized = resolvedResponseFormat.trim().toLowerCase();
+            if (normalized === 'json' || normalized === 'object' || normalized === 'json_object') {
+                return new StructuredOutput(
+                    { responseFormat: { type: 'json_object' }, schema: null, expectsJson: true },
+                    { responseFormat: { type: 'json_object' } }
+                );
+            }
+            return new StructuredOutput({ schema: null, expectsJson: false }, { responseFormat: resolvedResponseFormat });
+        }
+
+        if (resolvedOutputConfig && typeof resolvedOutputConfig === 'object' && !Array.isArray(resolvedOutputConfig)) {
+            const outputConfig = resolvedOutputConfig as Record<string, unknown>;
+            const format = (outputConfig.format && typeof outputConfig.format === 'object' && !Array.isArray(outputConfig.format))
+                ? outputConfig.format as Record<string, unknown>
+                : null;
+            const schema = format ? StructuredOutput.extractJsonSchema(format) : null;
+            const expectsJson = format?.type === 'json_schema' || schema !== null;
+            return new StructuredOutput(
+                { outputConfig, schema, expectsJson },
+                { outputConfig }
+            );
+        }
+
+        if (!resolvedResponseFormat || typeof resolvedResponseFormat !== 'object' || Array.isArray(resolvedResponseFormat)) {
+            return new StructuredOutput({ schema: null, expectsJson: false }, {});
+        }
+
+        const format = resolvedResponseFormat as Record<string, unknown>;
+        if (format.type === 'json_object') {
+            return new StructuredOutput({ responseFormat: format, schema: null, expectsJson: true }, { responseFormat: format });
+        }
+
+        const schema = StructuredOutput.extractJsonSchema(format);
+        if (!schema) {
+            return new StructuredOutput({
+                responseFormat: format,
+                schema: null,
+                expectsJson: false,
+            }, { responseFormat: format });
+        }
+
+        return new StructuredOutput({
+            responseFormat: format,
+            schema,
+            expectsJson: true,
+        }, { responseFormat: format });
+    }
+
+    getRequestFields(requestField: 'response_format' | 'output_config' = 'response_format'): StructuredRequestFields {
+        if (requestField === 'output_config') {
+            if (this.source.outputConfig !== undefined) {
+                return { outputConfig: this.source.outputConfig };
+            }
+            const derivedOutputConfig = this.deriveOutputConfig();
+            return derivedOutputConfig !== undefined ? { outputConfig: derivedOutputConfig } : {};
+        }
+
+        if (this.source.responseFormat !== undefined) {
+            return { responseFormat: this.source.responseFormat };
+        }
+        const derivedResponseFormat = this.deriveResponseFormat();
+        return derivedResponseFormat !== undefined ? { responseFormat: derivedResponseFormat } : {};
+    }
+
+    parse(content: StructuredContent): StructuredContent {
+        if (!this.config.expectsJson) return content;
+        if (StructuredOutput.isToolCallResult(content)) return content;
+
+        const validated = (obj: Record<string, unknown>, raw: unknown): Record<string, unknown> => {
+            if (!this.config.schema) return obj;
+            const issues = StructuredOutput.validateAgainstSchema(obj, this.config.schema);
+            if (issues) {
+                throw new StructuredOutputError(
+                    'SCHEMA_MISMATCH',
+                    'Schema mismatch: response JSON does not match required fields/types',
+                    raw,
+                    issues
+                );
+            }
+            return obj;
+        };
+
+        if (content && typeof content === 'object') {
+            if (Array.isArray(content)) {
+                throw new StructuredOutputError('JSON_MODE_FAILURE', 'JSON response must be an object', content);
+            }
+            return validated(content as Record<string, unknown>, content);
+        }
+
+        if (typeof content === 'string') {
+            const parsed = StructuredOutput.normalizeJsonContent(content);
+            return validated(parsed, content);
+        }
+
+        return content;
+    }
+
+    // Backward-compatible internal alias.
+    normalize(content: StructuredContent): StructuredContent {
+        return this.parse(content);
+    }
+
+    private static extractJsonSchema(format: Record<string, unknown>): Record<string, unknown> | null {
+        if (format.type === 'json_schema' && 'json_schema' in format) {
+            const wrapper = format.json_schema as Record<string, unknown> | undefined;
+            if (wrapper?.schema && typeof wrapper.schema === 'object' && !Array.isArray(wrapper.schema)) {
+                return wrapper.schema as Record<string, unknown>;
+            }
+        }
+        if (format.type === 'json_schema' && format.schema && typeof format.schema === 'object' && !Array.isArray(format.schema)) {
+            return format.schema as Record<string, unknown>;
+        }
+        if (format.type === 'object' || 'properties' in format || 'required' in format) {
+            return format;
+        }
+        if (format.schema && typeof format.schema === 'object' && !Array.isArray(format.schema)) {
+            return format.schema as Record<string, unknown>;
+        }
+        return null;
+    }
+
+    private static assertNoAliasConflicts(inputs: StructuredOutputOptions): void {
+        if (inputs.responseFormat !== undefined && inputs.response_format !== undefined) {
+            throw new Error('Provide either "responseFormat" or "response_format", not both.');
+        }
+        if (inputs.outputConfig !== undefined && inputs.output_config !== undefined) {
+            throw new Error('Provide either "outputConfig" or "output_config", not both.');
+        }
+    }
+
+    private static resolveResponseFormatOption(responseFormat: unknown, responseFormatAlias: unknown): unknown {
+        if (responseFormatAlias !== undefined) {
+            return responseFormatAlias;
+        }
+        if (responseFormat && typeof responseFormat === 'object' && !Array.isArray(responseFormat)) {
+            const maybeWrapper = responseFormat as Record<string, unknown>;
+            if (maybeWrapper.responseFormat !== undefined) {
+                return maybeWrapper.responseFormat;
+            }
+            if (maybeWrapper.response_format !== undefined) {
+                return maybeWrapper.response_format;
+            }
+        }
+        return responseFormat;
+    }
+
+    private static resolveOutputConfigOption(
+        responseFormat: unknown,
+        responseFormatAlias: unknown,
+        outputConfig: unknown,
+        outputConfigAlias: unknown
+    ): unknown {
+        if (outputConfig !== undefined) {
+            return outputConfig;
+        }
+        if (outputConfigAlias !== undefined) {
+            return outputConfigAlias;
+        }
+        const wrappers = [responseFormat, responseFormatAlias];
+        for (const wrapper of wrappers) {
+            if (wrapper && typeof wrapper === 'object' && !Array.isArray(wrapper)) {
+                const maybeWrapper = wrapper as Record<string, unknown>;
+                if (maybeWrapper.outputConfig !== undefined) {
+                    return maybeWrapper.outputConfig;
+                }
+                if (maybeWrapper.output_config !== undefined) {
+                    return maybeWrapper.output_config;
+                }
+            }
+        }
+        return undefined;
+    }
+
+    private isJsonObjectFormat(value: unknown): boolean {
+        return !!value
+            && typeof value === 'object'
+            && !Array.isArray(value)
+            && (value as Record<string, unknown>).type === 'json_object';
+    }
+
+    private deriveOutputConfig(): unknown {
+        if (this.config.outputConfig !== undefined) {
+            return this.config.outputConfig;
+        }
+
+        if (this.config.responseFormat && this.isJsonObjectFormat(this.config.responseFormat)) {
+            // No user-provided schema: do not invent a restrictive schema.
+            // Providers that require schema-based structured config should receive no
+            // structured request field here and rely on best-effort post parsing.
+            return undefined;
+        }
+
+        if (this.config.schema) {
+            return { format: { type: 'json_schema', schema: this.config.schema } };
+        }
+
+        return undefined;
+    }
+
+    private deriveResponseFormat(): unknown {
+        if (this.config.responseFormat !== undefined) {
+            return this.config.responseFormat;
+        }
+
+        if (this.source.outputConfig && typeof this.source.outputConfig === 'object' && !Array.isArray(this.source.outputConfig)) {
+            const outputConfig = this.source.outputConfig as Record<string, unknown>;
+            const format = (outputConfig.format && typeof outputConfig.format === 'object' && !Array.isArray(outputConfig.format))
+                ? outputConfig.format as Record<string, unknown>
+                : null;
+
+            if (format?.type === 'json_object') {
+                return { type: 'json_object' };
+            }
+            if (format?.type === 'json_schema' && format.schema && typeof format.schema === 'object' && !Array.isArray(format.schema)) {
+                return {
+                    type: 'json_schema',
+                    json_schema: { name: 'structured_response', schema: format.schema },
+                };
+            }
+        }
+
+        if (this.config.schema) {
+            return {
+                type: 'json_schema',
+                json_schema: { name: 'structured_response', schema: this.config.schema },
+            };
+        }
+
+        return undefined;
+    }
+
+    private static normalizeJsonContent(content: string): Record<string, unknown> {
+        let parsed: unknown = null;
+        const candidates = StructuredOutput.buildJsonParseCandidates(content);
+        for (const candidate of candidates) {
+            try {
+                parsed = JSON.parse(candidate);
+                break;
+            } catch {
+                // Try next parse candidate.
+            }
+        }
+        if (parsed === null) {
+            throw new StructuredOutputError('JSON_PARSE_ERROR', 'JSON parse failed for structured response', content);
+        }
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            throw new StructuredOutputError('JSON_MODE_FAILURE', 'JSON response must be an object', content);
+        }
+        return parsed as Record<string, unknown>;
+    }
+
+    private static buildJsonParseCandidates(content: string): string[] {
+        const candidates: string[] = [];
+        const trimmed = content.trim();
+        if (!trimmed) return candidates;
+
+        candidates.push(trimmed);
+
+        // Common LLM output shape: fenced markdown JSON block.
+        const fullFenceMatch = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+        if (fullFenceMatch?.[1]) {
+            candidates.push(fullFenceMatch[1].trim());
+        }
+
+        // Fallback: first fenced block embedded in additional prose.
+        const embeddedFenceMatch = trimmed.match(/```(?:json)?\s*([\s\S]*?)\s*```/i);
+        if (embeddedFenceMatch?.[1]) {
+            candidates.push(embeddedFenceMatch[1].trim());
+        }
+
+        return Array.from(new Set(candidates));
+    }
+
+    private static validateAgainstSchema(data: Record<string, unknown>, schema: Record<string, unknown>): SchemaValidationIssue | null {
+        const required = Array.isArray(schema.required)
+            ? schema.required.filter((r): r is string => typeof r === 'string')
+            : [];
+        const properties = (schema.properties && typeof schema.properties === 'object')
+            ? schema.properties as Record<string, Record<string, unknown>>
+            : {};
+
+        const missingFields = required.filter(field => !(field in data));
+        const extraFields = (schema.additionalProperties === false && Object.keys(properties).length > 0)
+            ? Object.keys(data).filter(key => !(key in properties))
+            : [];
+
+        const typeMismatches: SchemaValidationIssue['typeMismatches'] = [];
+        for (const [field, fieldSchema] of Object.entries(properties)) {
+            if (!(field in data) || !fieldSchema || typeof fieldSchema !== 'object') continue;
+            const expected = StructuredOutput.schemaPrimitiveType(fieldSchema);
+            if (!expected) continue;
+            const actual = StructuredOutput.runtimePrimitiveType(data[field]);
+            if (actual !== expected && !(expected === 'number' && actual === 'integer')) {
+                typeMismatches.push({ field, expected, actual });
+            }
+        }
+
+        if (missingFields.length === 0 && extraFields.length === 0 && typeMismatches.length === 0) {
+            return null;
+        }
+        return { missingFields, extraFields, typeMismatches };
+    }
+
+    private static schemaPrimitiveType(fieldSchema: Record<string, unknown>): string | null {
+        const t = fieldSchema.type;
+        const resolved = Array.isArray(t) ? t[0] : t;
+        return (resolved === 'string' || resolved === 'number' || resolved === 'boolean' || resolved === 'integer')
+            ? resolved as string
+            : null;
+    }
+
+    private static runtimePrimitiveType(value: unknown): string {
+        if (typeof value === 'string') return 'string';
+        if (typeof value === 'boolean') return 'boolean';
+        if (typeof value === 'number') return Number.isInteger(value) ? 'integer' : 'number';
+        if (value === null) return 'null';
+        if (Array.isArray(value)) return 'array';
+        if (typeof value === 'object') return 'object';
+        return typeof value;
+    }
+
+    private static isToolCallResult(value: unknown): value is StructuredToolCallResult {
+        return !!value && typeof value === 'object' && 'toolCalls' in value;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "tsc",
     "pretest": "tsc",
-    "test": "mocha 'test/**/*.test.js'",
+    "test": "tsc && mocha 'test/**/*.test.js' --ignore 'test/**/*.e2e.test.js'",
     "test:watch": "tsc --watch & mocha --watch 'test/**/*.test.js'",
     "test:coverage": "tsc && nyc mocha 'test/**/*.test.js'",
     "test:e2e": "tsc && mocha 'test/**/*.e2e.test.js' --timeout 60000",

--- a/test/chat.e2e.test.js
+++ b/test/chat.e2e.test.js
@@ -52,9 +52,9 @@ describe('ResilientLLM operations tests in real world, with real fetch', () => {
                 responseFormat: { type: 'json_object' }
             });
 
-            expect(result).to.be.an('object');
-            expect(result).to.have.property('answer');
-            expect(result).to.have.property('questionId');
+            expect(result.content).to.be.an('object');
+            expect(result.content).to.have.property('answer');
+            expect(result.content).to.have.property('questionId');
         }).timeout(30000);
 
         // Shared schema for OpenAI (response_format) and Anthropic (output_config) json_schema e2e checks.
@@ -90,12 +90,12 @@ describe('ResilientLLM operations tests in real world, with real fetch', () => {
                 responseFormat: mathAnswerJsonSchemaFormat
             });
 
-            expect(result).to.be.an('object');
-            expect(result).to.have.property('sum');
-            expect(result.sum).to.be.a('number');
-            expect(result).to.have.property('explanationSteps');
-            expect(result.explanationSteps).to.be.an('array');
-            result.explanationSteps.forEach(step => expect(step).to.be.a('string'));
+            expect(result.content).to.be.an('object');
+            expect(result.content).to.have.property('sum');
+            expect(result.content.sum).to.be.a('number');
+            expect(result.content).to.have.property('explanationSteps');
+            expect(result.content.explanationSteps).to.be.an('array');
+            result.content.explanationSteps.forEach(step => expect(step).to.be.a('string'));
         }).timeout(30000);
 
         // Same structured-output contract as OpenAI, via Anthropic Messages API (output_config.format).
@@ -113,12 +113,12 @@ describe('ResilientLLM operations tests in real world, with real fetch', () => {
                 responseFormat: mathAnswerJsonSchemaFormat
             });
 
-            expect(result).to.be.an('object');
-            expect(result).to.have.property('sum');
-            expect(result.sum).to.be.a('number');
-            expect(result).to.have.property('explanationSteps');
-            expect(result.explanationSteps).to.be.an('array');
-            result.explanationSteps.forEach(step => expect(step).to.be.a('string'));
+            expect(result.content).to.be.an('object');
+            expect(result.content).to.have.property('sum');
+            expect(result.content.sum).to.be.a('number');
+            expect(result.content).to.have.property('explanationSteps');
+            expect(result.content.explanationSteps).to.be.an('array');
+            result.content.explanationSteps.forEach(step => expect(step).to.be.a('string'));
         }).timeout(30000);
 
         it('should support output_config migration passthrough (real fetch)', async () => {
@@ -133,9 +133,9 @@ describe('ResilientLLM operations tests in real world, with real fetch', () => {
                 output_config: { format: { type: 'json_schema' } }
             });
 
-            expect(result).to.be.an('object');
-            expect(result).to.have.property('status');
-            expect(result.status).to.equal('ok');
+            expect(result.content).to.be.an('object');
+            expect(result.content).to.have.property('status');
+            expect(result.content.status).to.equal('ok');
         }).timeout(30000);
     });
 }); 

--- a/test/chat.e2e.test.js
+++ b/test/chat.e2e.test.js
@@ -2,975 +2,21 @@ import { ResilientLLM } from '../dist/index.js';
 import { describe, it, beforeEach, afterEach } from 'mocha';
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import sinon from 'sinon';
 
 // Configure chai to handle promises
 use(chaiAsPromised);
 
-// Mock environment variables for testing
+// Preserve environment for real-fetch tests
 const originalEnv = process.env;
-
-beforeEach(() => {
-    process.env = {
-        ...originalEnv,
-        OPENAI_API_KEY: 'test-openai-key',
-        ANTHROPIC_API_KEY: 'test-anthropic-key',
-        GEMINI_API_KEY: 'test-gemini-key',
-        OLLAMA_API_KEY: 'test-ollama-key',
-        OLLAMA_API_URL: 'http://localhost:11434/api/generate'
-    };
-});
 
 afterEach(() => {
     process.env = originalEnv;
-    sinon.restore();
 });
 
-describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
-    let llm;
-    let mockFetch;
-
-    beforeEach(() => {
-        mockFetch = sinon.stub();
-        global.fetch = mockFetch;
-        llm = new ResilientLLM({
-            aiService: 'openai',
-            model: 'gpt-4o-mini',
-            temperature: 0.7,
-            maxTokens: 2048,//output tokens LLM is allowed to generate
-            timeout: 30000,//timeout for the LLM request
-            rateLimitConfig: { requestsPerMinute: 60, llmTokensPerMinute: 150000 }//rate limit config for the LLM
-        });
-    });
-
-    describe('Basic Chat Functionality', () => {
-        it('should successfully chat with OpenAI service', async () => {
-            const mockResponse = {
-                id: 'chatcmpl-123',
-                object: 'chat.completion',
-                created: 1728933352,
-                model: 'gpt-4o-mini',
-                choices: [{
-                    index: 0,
-                    message: {
-                        role: 'assistant',
-                        content: 'Hello! How can I help you today?',
-                        refusal: null
-                    },
-                    logprobs: null,
-                    finish_reason: 'stop'
-                }],
-                usage: {
-                    prompt_tokens: 19,
-                    completion_tokens: 10,
-                    total_tokens: 29
-                }
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello, how are you?' }
-            ];
-
-            const response = await llm.chat(conversationHistory);
-            
-            sinon.assert.calledWith(
-                mockFetch,
-                'https://api.openai.com/v1/chat/completions',
-                sinon.match({
-                    method: 'POST',
-                    headers: sinon.match({
-                        'Content-Type': 'application/json',
-                        'Authorization': 'Bearer test-openai-key'
-                    }),
-                    body: sinon.match(/.*"model":"gpt-4o-mini".*/)
-                })
-            );
-            sinon.assert.calledOnce(mockFetch);
-            expect(response).to.exist;
-            expect(response).to.equal('Hello! How can I help you today?');
-        });
-
-        it('should successfully chat with Anthropic service', async () => {
-            const mockResponse = {
-                id: 'msg_123',
-                type: 'message',
-                role: 'assistant',
-                content: [{
-                    type: 'text',
-                    text: 'Hello! I am Claude, an AI assistant created by Anthropic. How can I help you today?'
-                }],
-                model: 'claude-haiku-4-5-20251001',
-                stop_reason: 'end_turn',
-                stop_sequence: null,
-                usage: {
-                    input_tokens: 12,
-                    output_tokens: 25
-                }
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const anthropicLLM = new ResilientLLM({
-                aiService: 'anthropic',
-                model: 'claude-haiku-4-5-20251001'
-            });
-
-            const conversationHistory = [
-                { role: 'system', content: 'You are a helpful assistant.' },
-                { role: 'user', content: 'Hello, how are you?' }
-            ];
-
-            const response = await anthropicLLM.chat(conversationHistory);
-            
-            expect(response).to.equal('Hello! I am Claude, an AI assistant created by Anthropic. How can I help you today?');
-            sinon.assert.calledWith(
-                mockFetch,
-                'https://api.anthropic.com/v1/messages',
-                sinon.match({
-                    method: 'POST',
-                    headers: sinon.match({
-                        'Content-Type': 'application/json',
-                        'x-api-key': 'test-anthropic-key',
-                        'anthropic-version': '2023-06-01'
-                    }),
-                    body: sinon.match(/.*"system":"You are a helpful assistant.".+/)
-                })
-            );
-        });
-
-        it('should successfully chat with Google service', async () => {
-            const mockResponse = {
-                id: 'chatcmpl-123',
-                object: 'chat.completion',
-                created: 1728933352,
-                model: 'gemini-2.0-flash',
-                choices: [{
-                    index: 0,
-                    message: {
-                        role: 'assistant',
-                        content: 'Hello! I am Gemini, how can I assist you today?',
-                        refusal: null
-                    },
-                    logprobs: null,
-                    finish_reason: 'stop'
-                }]
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const googleLLM = new ResilientLLM({
-                aiService: 'google',
-                model: 'gemini-2.0-flash'
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello, how are you?' }
-            ];
-
-            const response = await googleLLM.chat(conversationHistory);
-            
-            expect(response).to.equal('Hello! I am Gemini, how can I assist you today?');
-            sinon.assert.calledWith(
-                mockFetch,
-                'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
-                sinon.match({
-                    method: 'POST',
-                    headers: sinon.match({
-                        'Content-Type': 'application/json',
-                        'Authorization': 'Bearer test-gemini-key'
-                    })
-                })
-            );
-        });
-
-        it('should successfully chat with Ollama service', async () => {
-            const mockResponse = {
-                response: 'Hello! I am Llama, how can I help you today?',
-                done: true
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const ollamaLLM = new ResilientLLM({
-                aiService: 'ollama',
-                model: 'openai'
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello, how are you?' }
-            ];
-
-            const response = await ollamaLLM.chat(conversationHistory);
-            
-            expect(response).to.equal('Hello! I am Llama, how can I help you today?');
-            sinon.assert.calledWith(
-                mockFetch,
-                'http://localhost:11434/api/generate',
-                sinon.match({
-                    method: 'POST',
-                    headers: sinon.match({
-                        'Content-Type': 'application/json',
-                        'Authorization': 'Bearer test-ollama-key'
-                    })
-                })
-            );
-        });
-    });
-
-    describe('Tool Calling Support', () => {
-        it('should handle tool calls with OpenAI', async () => {
-            const mockResponse = {
-                id: 'chatcmpl-123',
-                object: 'chat.completion',
-                created: 1728933352,
-                model: 'gpt-4o-mini',
-                choices: [{
-                    index: 0,
-                    message: {
-                        role: 'assistant',
-                        content: null,
-                        tool_calls: [{
-                            id: 'call_123',
-                            type: 'function',
-                            function: {
-                                name: 'get_weather',
-                                arguments: '{"location": "New York"}'
-                            }
-                        }]
-                    },
-                    logprobs: null,
-                    finish_reason: 'tool_calls'
-                }],
-                usage: {
-                    prompt_tokens: 50,
-                    completion_tokens: 20,
-                    total_tokens: 70
-                }
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'What is the weather like in New York?' }
-            ];
-
-            const tools = [{
-                type: 'function',
-                function: {
-                    name: 'get_weather',
-                    description: 'Get the current weather in a given location',
-                    parameters: {
-                        type: 'object',
-                        properties: {
-                            location: {
-                                type: 'string',
-                                description: 'The city and state, e.g. San Francisco, CA'
-                            }
-                        },
-                        required: ['location']
-                    }
-                }
-            }];
-
-            const response = await llm.chat(conversationHistory, { tools });
-            
-            expect(response).to.deep.equal({
-                content: null,
-                toolCalls: [{
-                    id: 'call_123',
-                    type: 'function',
-                    function: {
-                        name: 'get_weather',
-                        arguments: '{"location": "New York"}'
-                    }
-                }]
-            });
-        });
-
-        it('should convert tool schema for Anthropic', async () => {
-            const mockResponse = {
-                id: 'msg_123',
-                type: 'message',
-                role: 'assistant',
-                content: [{
-                    type: 'text',
-                    text: 'I can help you get the weather information for New York.'
-                }],
-                model: 'claude-haiku-4-5-20251001',
-                stop_reason: 'end_turn',
-                usage: {
-                    input_tokens: 50,
-                    output_tokens: 15
-                }
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const anthropicLLM = new ResilientLLM({
-                aiService: 'anthropic',
-                model: 'claude-haiku-4-5-20251001'
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'What is the weather like in New York?' }
-            ];
-
-            const tools = [{
-                type: 'function',
-                function: {
-                    name: 'get_weather',
-                    description: 'Get the current weather in a given location',
-                    parameters: {
-                        type: 'object',
-                        properties: {
-                            location: {
-                                type: 'string',
-                                description: 'The city and state, e.g. San Francisco, CA'
-                            }
-                        },
-                        required: ['location']
-                    }
-                }
-            }];
-
-            const response = await anthropicLLM.chat(conversationHistory, { tools });
-            
-            expect(response).to.equal('I can help you get the weather information for New York.');
-            
-            // Verify that the request body contains the converted tool schema
-            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
-            expect(requestBody.tools[0].function.input_schema).to.exist;
-            expect(requestBody.tools[0].function.parameters).to.be.undefined;
-        });
-    });
-
-    describe('Error Handling', () => {
-        it('should handle 401 authentication errors', async () => {
-            const mockErrorResponse = {
-                error: {
-                    message: 'Invalid API key',
-                    type: 'invalid_request_error',
-                    param: null,
-                    code: 'invalid_api_key'
-                }
-            };
-
-            mockFetch.resolves({
-                ok: false,
-                status: 401,
-                json: async () => mockErrorResponse
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-
-            await expect(llm.chat(conversationHistory)).to.be.rejectedWith('Invalid API key');
-        });
-
-        it('should handle 429 rate limit errors and retry with alternate service', async () => {
-            const mockRateLimitResponse = {
-                error: {
-                    message: 'Rate limit exceeded',
-                    type: 'rate_limit_error',
-                    param: null,
-                    code: 'rate_limit_exceeded'
-                }
-            };
-
-            const mockAnthropicResponse = {
-                id: 'msg_123',
-                type: 'message',
-                role: 'assistant',
-                content: [{
-                    type: 'text',
-                    text: 'Hello from Anthropic fallback!'
-                }],
-                model: 'claude-haiku-4-5-20251001',
-                stop_reason: 'end_turn',
-                usage: {
-                    input_tokens: 12,
-                    output_tokens: 8
-                }
-            };
-
-            // First call to OpenAI fails with rate limit
-            mockFetch.onFirstCall().resolves({
-                ok: false,
-                status: 429,
-                json: async () => mockRateLimitResponse
-            });
-
-            // Second call to Anthropic succeeds
-            mockFetch.onSecondCall().resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockAnthropicResponse
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-
-            const response = await llm.chat(conversationHistory);
-            
-            expect(response).to.equal('Hello from Anthropic fallback!');
-            sinon.assert.calledTwice(mockFetch);
-            
-            // Verify first call was to OpenAI
-            expect(mockFetch.getCall(0).args[0]).to.equal('https://api.openai.com/v1/chat/completions');
-            
-            // Verify second call was to Anthropic
-            expect(mockFetch.getCall(1).args[0]).to.equal('https://api.anthropic.com/v1/messages');
-        });
-
-        it('should handle token limit exceeded', async () => {
-            const longText = 'a'.repeat(404040); // Very long text to exceed token limit
-            const conversationHistory = [
-                { role: 'user', content: longText }
-            ];
-
-            await expect(llm.chat(conversationHistory)).to.be.rejectedWith('Input tokens exceed the maximum limit');
-        });
-
-        it('should handle invalid AI service', async () => {
-            const invalidLLM = new ResilientLLM({
-                aiService: 'invalid-service'
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-
-            await expect(invalidLLM.chat(conversationHistory)).to.be.rejectedWith('Invalid provider specified');
-        });
-
-        it('should handle missing API key', async () => {
-            process.env.OPENAI_API_KEY = '';
-            
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-            await expect(llm.chat(conversationHistory)).to.be.rejected;
-        });
-    });
-
-    describe('LLM Options and Configuration', () => {
-        it('should handle custom temperature and max tokens', async () => {
-            const mockResponse = {
-                id: 'chatcmpl-123',
-                object: 'chat.completion',
-                created: 1728933352,
-                model: 'gpt-4o-mini',
-                choices: [{
-                    index: 0,
-                    message: {
-                        role: 'assistant',
-                        content: 'Response with custom parameters',
-                        refusal: null
-                    },
-                    logprobs: null,
-                    finish_reason: 'stop'
-                }]
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-
-            const customOptions = {
-                temperature: 1.0,
-                maxTokens: 4000,
-                topP: 0.8
-            };
-
-            const response = await llm.chat(conversationHistory, customOptions);
-            
-            expect(response).to.equal('Response with custom parameters');
-            
-            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
-            expect(requestBody.temperature).to.equal(1.0);
-            expect(requestBody.max_tokens).to.equal(4000);
-            expect(requestBody.top_p).to.equal(0.8);
-        });
-
-        it('should handle reasoning models (o1) with different parameters', async () => {
-            const mockResponse = {
-                id: 'chatcmpl-123',
-                object: 'chat.completion',
-                created: 1728933352,
-                model: 'o1-preview',
-                choices: [{
-                    index: 0,
-                    message: {
-                        role: 'assistant',
-                        content: 'Reasoning model response',
-                        refusal: null
-                    },
-                    logprobs: null,
-                    finish_reason: 'stop'
-                }]
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Solve this complex problem' }
-            ];
-
-            const reasoningOptions = {
-                model: 'o1-preview',
-                maxCompletionTokens: 8000,
-                reasoningEffort: 'high'
-            };
-
-            const response = await llm.chat(conversationHistory, reasoningOptions);
-            
-            expect(response).to.equal('Reasoning model response');
-            
-            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
-            expect(requestBody.max_completion_tokens).to.equal(8000);
-            expect(requestBody.reasoning_effort).to.equal('high');
-            expect(requestBody.temperature).to.be.undefined; // Should not be set for reasoning models
-        });
-
-        it('should handle response format specification', async () => {
-            const mockResponse = {
-                id: 'chatcmpl-123',
-                object: 'chat.completion',
-                created: 1728933352,
-                model: 'gpt-4o-mini',
-                choices: [{
-                    index: 0,
-                    message: {
-                        role: 'assistant',
-                        content: '{"answer": "42"}',
-                        refusal: null
-                    },
-                    logprobs: null,
-                    finish_reason: 'stop'
-                }]
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'What is the answer to life, the universe, and everything? Respond in JSON format.' }
-            ];
-
-            const jsonOptions = {
-                responseFormat: { type: 'json_object' }
-            };
-
-            const response = await llm.chat(conversationHistory, jsonOptions);
-            
-            expect(response).to.equal('{"answer": "42"}');
-            
-            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
-            expect(requestBody.response_format).to.deep.equal({ type: 'json_object' });
-        });
-
-        it('should override service and model in options', async () => {
-            const mockResponse = {
-                id: 'msg_123',
-                type: 'message',
-                role: 'assistant',
-                content: [{
-                    type: 'text',
-                    text: 'Response from overridden service'
-                }],
-                model: 'claude-haiku-4-5-20251001',
-                stop_reason: 'end_turn',
-                usage: {
-                    input_tokens: 12,
-                    output_tokens: 8
-                }
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-
-            const overrideOptions = {
-                aiService: 'anthropic',
-                model: 'claude-haiku-4-5-20251001'
-            };
-
-            const response = await llm.chat(conversationHistory, overrideOptions);
-            
-            expect(response).to.equal('Response from overridden service');
-            sinon.assert.calledWith(
-                mockFetch,
-                'https://api.anthropic.com/v1/messages',
-                sinon.match({
-                    method: 'POST',
-                    headers: sinon.match({
-                        'x-api-key': 'test-anthropic-key'
-                    })
-                })
-            );
-        });
-    });
-
-    describe('Rate Limiting and Resilience', () => {
-        it('should handle rate limiting with token bucket', async () => {
-            const rateLimitedLLM = new ResilientLLM({
-                aiService: 'openai',
-                rateLimitConfig: { requestsPerMinute: 1, llmTokensPerMinute: 1000 }
-            });
-
-            const mockResponse = {
-                id: 'chatcmpl-123',
-                object: 'chat.completion',
-                created: 1728933352,
-                model: 'gpt-4o-mini',
-                choices: [{
-                    index: 0,
-                    message: {
-                        role: 'assistant',
-                        content: 'Response 1',
-                        refusal: null
-                    },
-                    logprobs: null,
-                    finish_reason: 'stop'
-                }]
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-
-            // First request should succeed
-            const response1 = await rateLimitedLLM.chat(conversationHistory);
-            expect(response1).to.equal('Response 1');
-
-            // Second request should also succeed but might be rate limited
-            const response2 = await rateLimitedLLM.chat(conversationHistory);
-            expect(response2).to.equal('Response 1');
-        });
-
-        it('should surface oversized token request errors before making network call', async () => {
-            const oversizedTokenLLM = new ResilientLLM({
-                aiService: 'openai',
-                model: 'gpt-4o-mini',
-                maxInputTokens: 50000,
-                rateLimitConfig: { requestsPerMinute: 60, llmTokensPerMinute: 1000 }
-            });
-
-            sinon.stub(ResilientLLM, 'estimateTokens').returns(1001);
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-
-            await expect(
-                oversizedTokenLLM.chat(conversationHistory)
-            ).to.be.rejectedWith('Cannot remove more tokens than the bucket capacity');
-
-            sinon.assert.notCalled(mockFetch);
-        });
-
-        it('should handle timeout scenarios', async () => {
-            const timeoutLLM = new ResilientLLM({
-                aiService: 'openai',
-                timeout: 1000 // 1 second timeout
-            });
-
-            // Mock a delayed response
-            mockFetch.callsFake(() => 
-                new Promise((resolve) => {
-                    setTimeout(() => resolve({
-                        ok: true,
-                        status: 200,
-                        json: async () => ({ choices: [{ message: { content: 'Late response' } }] })
-                    }), 2000); // 2 second delay
-                })
-            );
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-            await expect(timeoutLLM.chat(conversationHistory)).to.be.rejectedWith('Operation timed out');
-        });
-    });
-
-    describe('Conversation History Formatting', () => {
-        it('should format system messages correctly for Anthropic', async () => {
-            const mockResponse = {
-                id: 'msg_123',
-                type: 'message',
-                role: 'assistant',
-                content: [{
-                    type: 'text',
-                    text: 'Hello, I understand my role as a helpful assistant.'
-                }],
-                model: 'claude-haiku-4-5-20251001',
-                stop_reason: 'end_turn',
-                usage: {
-                    input_tokens: 30,
-                    output_tokens: 12
-                }
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const anthropicLLM = new ResilientLLM({
-                aiService: 'anthropic',
-                model: 'claude-haiku-4-5-20251001'
-            });
-
-            const conversationHistory = [
-                { role: 'system', content: 'You are a helpful assistant specialized in programming.' },
-                { role: 'user', content: 'Hello' },
-                { role: 'assistant', content: 'Hi there! How can I help you with programming?' },
-                { role: 'user', content: 'What is JavaScript?' }
-            ];
-
-            const response = await anthropicLLM.chat(conversationHistory);
-            
-            expect(response).to.equal('Hello, I understand my role as a helpful assistant.');
-            
-            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
-            expect(requestBody.system).to.equal('You are a helpful assistant specialized in programming.');
-            expect(requestBody.messages).to.have.length(3); // System message should be removed from messages array
-            expect(requestBody.messages[0].role).to.equal('user');
-        });
-
-        it('should handle empty conversation history', async () => {
-            const mockResponse = {
-                id: 'chatcmpl-123',
-                object: 'chat.completion',
-                created: 1728933352,
-                model: 'gpt-4o-mini',
-                choices: [{
-                    index: 0,
-                    message: {
-                        role: 'assistant',
-                        content: 'How can I help you?',
-                        refusal: null
-                    },
-                    logprobs: null,
-                    finish_reason: 'stop'
-                }]
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const response = await llm.chat([]);
-            
-            expect(response).to.equal('How can I help you?');
-        });
-    });
-
-    describe('Fallback and Retry Logic', () => {
-        it('should exhaust all services before failing', async () => {
-            const mockErrorResponse = {
-                error: {
-                    message: 'Service unavailable',
-                    type: 'service_unavailable',
-                    code: 'service_unavailable'
-                }
-            };
-
-            // Mock all services to return 429 (rate limited)
-            mockFetch.resolves({
-                ok: false,
-                status: 429,
-                json: async () => mockErrorResponse
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-
-            await expect(llm.chat(conversationHistory)).to.be.rejectedWith('No alternative model found');
-            
-            // Should try multiple services (OpenAI, then Anthropic, then Google, then Ollama)
-            sinon.assert.callCount(mockFetch, 4);
-        }).timeout(35000);
-
-        it('should succeed with second service when first fails', async () => {
-            const mockErrorResponse = {
-                error: {
-                    message: 'Service unavailable',
-                    type: 'service_unavailable',
-                    code: 'service_unavailable'
-                }
-            };
-
-            const mockSuccessResponse = {
-                id: 'msg_123',
-                type: 'message',
-                role: 'assistant',
-                content: [{
-                    type: 'text',
-                    text: 'Hello from backup service!'
-                }],
-                model: 'claude-haiku-4-5-20251001',
-                stop_reason: 'end_turn',
-                usage: {
-                    input_tokens: 12,
-                    output_tokens: 8
-                }
-            };
-
-            // First call fails
-            mockFetch.onFirstCall().resolves({
-                ok: false,
-                status: 429,
-                json: async () => mockErrorResponse
-            });
-
-            // Second call succeeds
-            mockFetch.onSecondCall().resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockSuccessResponse
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-
-            const response = await llm.chat(conversationHistory);
-            
-            expect(response).to.equal('Hello from backup service!');
-            sinon.assert.calledTwice(mockFetch);
-        });
-    }).timeout(35000);
-
-    describe('Edge Cases and Special Scenarios', () => {
-        it('should handle malformed API responses gracefully', async () => {
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => ({ malformed: 'response' })
-            });
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-
-            const response = await llm.chat(conversationHistory);
-            
-            expect(response).to.be.null; // Should handle gracefully
-        });
-
-        it('should handle network errors', async () => {
-            mockFetch.rejects(new Error('Network error'));
-
-            const conversationHistory = [
-                { role: 'user', content: 'Hello' }
-            ];
-
-            await expect(llm.chat(conversationHistory)).to.be.rejectedWith('Network error');
-        });
-
-        it('should handle very long conversation histories', async () => {
-            const longConversationHistory = [];
-            for (let i = 0; i < 10000; i++) {
-                longConversationHistory.push({
-                    role: i % 2 === 0 ? 'user' : 'assistant',
-                    content: `Message ${i}: This is a test message to create a long conversation history.`
-                });
-            }
-            await expect(llm.chat(longConversationHistory)).to.be.rejectedWith('Input tokens exceed the maximum limit');
-        });
-
-        it('should handle special characters in conversation', async () => {
-            const mockResponse = {
-                id: 'chatcmpl-123',
-                object: 'chat.completion',
-                created: 1728933352,
-                model: 'gpt-4o-mini',
-                choices: [{
-                    index: 0,
-                    message: {
-                        role: 'assistant',
-                        content: 'I can handle special characters: 你好, здравствуй, 🚀',
-                        refusal: null
-                    },
-                    logprobs: null,
-                    finish_reason: 'stop'
-                }]
-            };
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-            const conversationHistory = [
-                { role: 'user', content: 'Hello in different languages: 你好, здравствуй, 🚀' }
-            ];
-            const response = await llm.chat(conversationHistory);            
-            expect(response).to.equal('I can handle special characters: 你好, здравствуй, 🚀');
-        });
-    });
-}).timeout(20000);
-
-describe('ResilientLLM Chat Function E2E Tests with real fetch', () => {
+describe('ResilientLLM operations tests in real world, with real fetch', () => {
     let llm;
     beforeEach(() => {
+        process.env = { ...originalEnv };
         llm = new ResilientLLM({
             aiService: 'openai',
             model: 'gpt-4o-mini',
@@ -992,4 +38,124 @@ describe('ResilientLLM Chat Function E2E Tests with real fetch', () => {
             expect(error.name).to.equal('AbortError');
         }
     }).timeout(20000);
+
+    describe('Structured output test with real fetch', () => {
+        it('should return valid JSON when using json_object response format (real fetch)', async () => {
+            const conversationHistory = [
+                {
+                    role: 'user',
+                    content: 'Return a small JSON object with fields "answer" (string) and "questionId" (number).'
+                }
+            ];
+
+            const result = await llm.chat(conversationHistory, {
+                responseFormat: { type: 'json_object' }
+            });
+
+            expect(result).to.be.an('object');
+            expect(result).to.have.property('answer');
+            expect(result).to.have.property('questionId');
+        }).timeout(30000);
+
+        it('should respect a basic json_schema response format (real fetch)', async () => {
+            const schemaResponseFormat = {
+                type: 'json_schema',
+                json_schema: {
+                    name: 'math_answer',
+                    schema: {
+                        type: 'object',
+                        properties: {
+                            sum: { type: 'number' }
+                        },
+                        required: ['sum']
+                    }
+                }
+            };
+
+            const conversationHistory = [
+                {
+                    role: 'user',
+                    content: 'Add 2 and 3 and respond ONLY with JSON matching the schema where "sum" is the numeric result.'
+                }
+            ];
+
+            const result = await llm.chat(conversationHistory, {
+                responseFormat: schemaResponseFormat
+            });
+
+            expect(result).to.be.an('object');
+            expect(result).to.have.property('sum');
+            expect(result.sum).to.be.a('number');
+        }).timeout(30000);
+
+        it('should support snake_case response_format passthrough (real fetch)', async () => {
+            const conversationHistory = [
+                {
+                    role: 'user',
+                    content: 'Return ONLY a JSON object with one field "status" set to "ok".'
+                }
+            ];
+
+            const rawResult = await llm.chat(conversationHistory, {
+                response_format: { type: 'json_object' },
+                parseStructuredOutput: false
+            });
+            expect(rawResult).to.be.a('string');
+
+            const raw = rawResult.trim();
+            const isFencedJson = /^```(?:json)?\s*[\s\S]*\s*```$/i.test(raw);
+            const isPlainJson = !isFencedJson && (() => {
+                try {
+                    const parsed = JSON.parse(raw);
+                    return !!parsed && typeof parsed === 'object' && !Array.isArray(parsed);
+                } catch {
+                    return false;
+                }
+            })();
+            expect(isFencedJson || isPlainJson).to.equal(true, 'raw response should be plain JSON or fenced JSON');
+
+            const result = await llm.chat(conversationHistory, {
+                response_format: { type: 'json_object' }
+            });
+
+            expect(result).to.be.an('object');
+            expect(result).to.have.property('status');
+            expect(result.status).to.equal('ok');
+        }).timeout(30000);
+
+        it('should support snake_case output_config passthrough (real fetch)', async () => {
+            const conversationHistory = [
+                {
+                    role: 'user',
+                    content: 'Return ONLY a JSON object with one field "status" set to "ok".'
+                }
+            ];
+
+            const rawResult = await llm.chat(conversationHistory, {
+                output_config: { format: { type: 'json_schema' } },
+                parseStructuredOutput: false
+            });
+            expect(rawResult).to.be.a('string');
+
+            const raw = rawResult.trim();
+            const isFencedJson = /^```(?:json)?\s*[\s\S]*\s*```$/i.test(raw);
+            const isPlainJson = !isFencedJson && (() => {
+                try {
+                    const parsed = JSON.parse(raw);
+                    return !!parsed && typeof parsed === 'object' && !Array.isArray(parsed);
+                } catch {
+                    return false;
+                }
+            })();
+            expect(isFencedJson || isPlainJson).to.equal(true, 'raw response should be plain JSON or fenced JSON');
+
+            const result = await llm.chat(conversationHistory, {
+                output_config: { format: { type: 'json_schema' } }
+            });
+
+            expect(result).to.be.an('object');
+            expect(result).to.have.property('status');
+            expect(result.status).to.equal('ok');
+        }).timeout(30000);
+    });
 }); 

--- a/test/chat.e2e.test.js
+++ b/test/chat.e2e.test.js
@@ -57,97 +57,77 @@ describe('ResilientLLM operations tests in real world, with real fetch', () => {
             expect(result).to.have.property('questionId');
         }).timeout(30000);
 
-        it('should respect a basic json_schema response format (real fetch)', async () => {
-            const schemaResponseFormat = {
-                type: 'json_schema',
-                json_schema: {
-                    name: 'math_answer',
-                    schema: {
-                        type: 'object',
-                        properties: {
-                            sum: { type: 'number' }
-                        },
-                        required: ['sum']
-                    }
+        // Shared schema for OpenAI (response_format) and Anthropic (output_config) json_schema e2e checks.
+        const mathAnswerJsonSchemaFormat = {
+            type: 'json_schema',
+            json_schema: {
+                name: 'math_answer',
+                schema: {
+                    type: 'object',
+                    properties: {
+                        sum: { type: 'number' },
+                        explanationSteps: {
+                            type: 'array',
+                            items: { type: 'string' }
+                        }
+                    },
+                    required: ['sum', 'explanationSteps'],
+                    // Anthropic Messages structured output requires explicit false here for object roots.
+                    additionalProperties: false
                 }
-            };
+            }
+        };
 
-            const conversationHistory = [
-                {
-                    role: 'user',
-                    content: 'Add 2 and 3 and respond ONLY with JSON matching the schema where "sum" is the numeric result.'
-                }
-            ];
+        const mathAnswerConversation = [
+            {
+                role: 'user',
+                content: 'Add 2 and 3 and respond ONLY with JSON matching the schema where "sum" is the numeric result and "explanationSteps" is an array of short strings.'
+            }
+        ];
 
-            const result = await llm.chat(conversationHistory, {
-                responseFormat: schemaResponseFormat
+        it('should respect a more complex json_schema response format with OpenAI (real fetch)', async () => {
+            const result = await llm.chat(mathAnswerConversation, {
+                responseFormat: mathAnswerJsonSchemaFormat
             });
 
             expect(result).to.be.an('object');
             expect(result).to.have.property('sum');
             expect(result.sum).to.be.a('number');
+            expect(result).to.have.property('explanationSteps');
+            expect(result.explanationSteps).to.be.an('array');
+            result.explanationSteps.forEach(step => expect(step).to.be.a('string'));
         }).timeout(30000);
 
-        it('should support snake_case response_format passthrough (real fetch)', async () => {
-            const conversationHistory = [
-                {
-                    role: 'user',
-                    content: 'Return ONLY a JSON object with one field "status" set to "ok".'
-                }
-            ];
-
-            const rawResult = await llm.chat(conversationHistory, {
-                response_format: { type: 'json_object' },
-                parseStructuredOutput: false
+        // Same structured-output contract as OpenAI, via Anthropic Messages API (output_config.format).
+        it('should respect a more complex json_schema response format with Anthropic (real fetch)', async () => {
+            const anthropicLlm = new ResilientLLM({
+                aiService: 'anthropic',
+                model: 'claude-haiku-4-5-20251001',
+                temperature: 0.7,
+                maxTokens: 2048,
+                timeout: 30000,
+                rateLimitConfig: { requestsPerMinute: 60, llmTokensPerMinute: 150000 }
             });
-            expect(rawResult).to.be.a('string');
 
-            const raw = rawResult.trim();
-            const isFencedJson = /^```(?:json)?\s*[\s\S]*\s*```$/i.test(raw);
-            const isPlainJson = !isFencedJson && (() => {
-                try {
-                    const parsed = JSON.parse(raw);
-                    return !!parsed && typeof parsed === 'object' && !Array.isArray(parsed);
-                } catch {
-                    return false;
-                }
-            })();
-            expect(isFencedJson || isPlainJson).to.equal(true, 'raw response should be plain JSON or fenced JSON');
-
-            const result = await llm.chat(conversationHistory, {
-                response_format: { type: 'json_object' }
+            const result = await anthropicLlm.chat(mathAnswerConversation, {
+                responseFormat: mathAnswerJsonSchemaFormat
             });
 
             expect(result).to.be.an('object');
-            expect(result).to.have.property('status');
-            expect(result.status).to.equal('ok');
+            expect(result).to.have.property('sum');
+            expect(result.sum).to.be.a('number');
+            expect(result).to.have.property('explanationSteps');
+            expect(result.explanationSteps).to.be.an('array');
+            result.explanationSteps.forEach(step => expect(step).to.be.a('string'));
         }).timeout(30000);
 
-        it('should support snake_case output_config passthrough (real fetch)', async () => {
+        it('should support output_config migration passthrough (real fetch)', async () => {
             const conversationHistory = [
                 {
                     role: 'user',
                     content: 'Return ONLY a JSON object with one field "status" set to "ok".'
                 }
             ];
-
-            const rawResult = await llm.chat(conversationHistory, {
-                output_config: { format: { type: 'json_schema' } },
-                parseStructuredOutput: false
-            });
-            expect(rawResult).to.be.a('string');
-
-            const raw = rawResult.trim();
-            const isFencedJson = /^```(?:json)?\s*[\s\S]*\s*```$/i.test(raw);
-            const isPlainJson = !isFencedJson && (() => {
-                try {
-                    const parsed = JSON.parse(raw);
-                    return !!parsed && typeof parsed === 'object' && !Array.isArray(parsed);
-                } catch {
-                    return false;
-                }
-            })();
-            expect(isFencedJson || isPlainJson).to.equal(true, 'raw response should be plain JSON or fenced JSON');
 
             const result = await llm.chat(conversationHistory, {
                 output_config: { format: { type: 'json_schema' } }

--- a/test/chat.integration.test.js
+++ b/test/chat.integration.test.js
@@ -710,21 +710,15 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
     });
 
 
-    describe('Structured output test with mocked fetch', () => {
-        it('happy path: should normalize schema-based response into object', async () => {
+    describe('Structured output pipeline (normalize -> map -> parse -> validate)', () => {
+        it('happy path: schema-based responseFormat produces parsed + validated object', async () => {
             const mockResponse = {
                 id: 'chatcmpl-123',
                 object: 'chat.completion',
                 created: 1728933352,
                 model: 'gpt-4o-mini',
                 choices: [{
-                    index: 0,
-                    message: {
-                        role: 'assistant',
-                        content: '{"answer": "42"}',
-                        refusal: null
-                    },
-                    logprobs: null,
+                    message: { role: 'assistant', content: '{"answer": "42"}' },
                     finish_reason: 'stop'
                 }]
             };
@@ -735,27 +729,22 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
                 json: async () => mockResponse
             });
 
-            const conversationHistory = [
-                { role: 'user', content: 'What is the answer to life, the universe, and everything? Respond in JSON format.' }
-            ];
-
-            const jsonSchemaOptions = {
-                responseFormat: {
-                    type: 'json_schema',
-                    json_schema: {
-                        name: 'answer_payload',
-                        schema: {
-                            type: 'object',
-                            properties: {
-                                answer: { type: 'string' }
-                            },
-                            required: ['answer']
+            const response = await llm.chat(
+                [{ role: 'user', content: 'Return JSON.' }],
+                {
+                    responseFormat: {
+                        type: 'json_schema',
+                        json_schema: {
+                            name: 'answer_payload',
+                            schema: {
+                                type: 'object',
+                                properties: { answer: { type: 'string' } },
+                                required: ['answer']
+                            }
                         }
                     }
                 }
-            };
-
-            const response = await llm.chat(conversationHistory, jsonSchemaOptions);
+            );
 
             expect(response).to.deep.equal({ answer: '42' });
             
@@ -764,14 +753,12 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
             expect(requestBody.response_format.json_schema.schema.required).to.deep.equal(['answer']);
         });
 
-        it('should not synthesize Anthropic output_config when no schema is provided', async () => {
+        it('edge case: fenced JSON is parsed via best_effort when using string alias', async () => {
             const mockResponse = {
-                id: 'msg_123',
-                type: 'message',
-                role: 'assistant',
-                content: [{ type: 'text', text: '{"answer":"42"}' }],
-                stop_reason: 'end_turn',
-                usage: { input_tokens: 10, output_tokens: 5 }
+                choices: [{
+                    message: { role: 'assistant', content: '```json\n{"status":"ok"}\n```' },
+                    finish_reason: 'stop'
+                }]
             };
 
             mockFetch.resolves({
@@ -780,181 +767,18 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
                 json: async () => mockResponse
             });
 
-            const anthropicLLM = new ResilientLLM({
-                aiService: 'anthropic',
-                model: 'claude-haiku-4-5-20251001'
-            });
-
-            await anthropicLLM.chat(
-                [{ role: 'user', content: 'Return JSON object with answer.' }],
+            const response = await llm.chat(
+                [{ role: 'user', content: 'Return JSON.' }],
                 { responseFormat: 'json' }
             );
 
-            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
-            expect(requestBody.output_config).to.equal(undefined);
-            expect(requestBody.response_format).to.equal(undefined);
+            expect(response).to.deep.equal({ status: 'ok' });
         });
 
-        it('should pass through explicit output_config without modifying it', async () => {
-            const mockResponse = {
-                id: 'msg_123',
-                type: 'message',
-                role: 'assistant',
-                content: [{ type: 'text', text: '{"answer":"42"}' }],
-                stop_reason: 'end_turn',
-                usage: { input_tokens: 10, output_tokens: 5 }
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const anthropicLLM = new ResilientLLM({
-                aiService: 'anthropic',
-                model: 'claude-haiku-4-5-20251001'
-            });
-            const output_config = { format: { type: 'json_schema' } };
-
-            const response = await anthropicLLM.chat(
-                [{ role: 'user', content: 'Return JSON object with answer.' }],
-                { output_config }
-            );
-
-            expect(response).to.deep.equal({ answer: '42' });
-            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
-            expect(requestBody.output_config).to.deep.equal(output_config);
-            expect(requestBody.response_format).to.equal(undefined);
-        });
-
-        it('should pass through explicit response_format without modifying it', async () => {
+        it('failure: invalid JSON surfaces JSON_PARSE_ERROR and logs debug output', async () => {
             const mockResponse = {
                 choices: [{
-                    message: {
-                        role: 'assistant',
-                        content: '{"answer":"42"}',
-                    },
-                    finish_reason: 'stop'
-                }]
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const response_format = { type: 'json_schema', json_schema: { name: 'answer_payload', schema: { type: 'object' } } };
-            const response = await llm.chat(
-                [{ role: 'user', content: 'Return JSON object with answer.' }],
-                { response_format }
-            );
-
-            expect(response).to.deep.equal({ answer: '42' });
-            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
-            expect(requestBody.response_format).to.deep.equal(response_format);
-        });
-
-        it('should fail fast when both responseFormat and response_format are provided', async () => {
-            await expect(
-                llm.chat(
-                    [{ role: 'user', content: 'Return JSON only.' }],
-                    {
-                        responseFormat: { type: 'json_object' },
-                        response_format: { type: 'json_object' }
-                    }
-                )
-            ).to.be.rejectedWith('Provide either "responseFormat" or "response_format", not both.');
-
-            sinon.assert.notCalled(mockFetch);
-        });
-
-        it('should parse markdown-fenced JSON in structured output mode', async () => {
-            const mockResponse = {
-                choices: [{
-                    message: {
-                        role: 'assistant',
-                        content: '```json\n{"answer":"42"}\n```',
-                    },
-                    finish_reason: 'stop'
-                }]
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const response = await llm.chat(
-                [{ role: 'user', content: 'Return JSON only.' }],
-                { responseFormat: 'json' }
-            );
-
-            expect(response).to.deep.equal({ answer: '42' });
-        });
-
-        it('edge case: should fail clearly when JSON parsing fails', async () => {
-            const mockResponse = {
-                choices: [{
-                    message: {
-                        role: 'assistant',
-                        content: '{"answer": "42"',
-                    },
-                    finish_reason: 'stop'
-                }]
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            await expect(
-                llm.chat(
-                    [{ role: 'user', content: 'Return JSON only.' }],
-                    { responseFormat: 'json' }
-                )
-            ).to.be.rejectedWith('JSON parse failed for structured response');
-        });
-
-        it('should return raw content when parseStructuredOutput is false', async () => {
-            const mockResponse = {
-                choices: [{
-                    message: {
-                        role: 'assistant',
-                        content: '{"answer":"42"}',
-                    },
-                    finish_reason: 'stop'
-                }]
-            };
-
-            mockFetch.resolves({
-                ok: true,
-                status: 200,
-                json: async () => mockResponse
-            });
-
-            const response = await llm.chat(
-                [{ role: 'user', content: 'Return JSON only.' }],
-                {
-                    responseFormat: { type: 'json_object' },
-                    parseStructuredOutput: false
-                }
-            );
-
-            expect(response).to.equal('{"answer":"42"}');
-        });
-
-        it('edge case: should return schema mismatch details for missing fields and wrong type', async () => {
-            const mockResponse = {
-                choices: [{
-                    message: {
-                        role: 'assistant',
-                        content: '{"title":123}',
-                    },
+                    message: { role: 'assistant', content: 'this is not json' },
                     finish_reason: 'stop'
                 }]
             };
@@ -967,7 +791,34 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             try {
                 await llm.chat(
-                    [{ role: 'user', content: 'Return schema-constrained JSON.' }],
+                    [{ role: 'user', content: 'Return JSON.' }],
+                    { responseFormat: 'json' }
+                );
+                throw new Error('Expected JSON_PARSE_ERROR to be thrown');
+            } catch (error) {
+                expect(error.code).to.equal('JSON_PARSE_ERROR');
+                expect(error.rawResponse).to.equal('this is not json');
+                expect(error.validation).to.equal(null);
+            }
+        });
+
+        it('failure: schema mismatch surfaces code, validation details, and raw response', async () => {
+            const mockResponse = {
+                choices: [{
+                    message: { role: 'assistant', content: '{"title":123}' },
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            try {
+                await llm.chat(
+                    [{ role: 'user', content: 'Return schema JSON.' }],
                     {
                         responseFormat: {
                             type: 'json_schema',
@@ -993,7 +844,6 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
                 expect(error.validation.typeMismatches).to.deep.equal([
                     { field: 'title', expected: 'string', actual: 'integer' }
                 ]);
-                expect(error.rawResponse).to.equal('{"title":123}');
             }
         });
     });

--- a/test/chat.integration.test.js
+++ b/test/chat.integration.test.js
@@ -95,7 +95,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
             );
             sinon.assert.calledOnce(mockFetch);
             expect(response).to.exist;
-            expect(response).to.equal('Hello! How can I help you today?');
+            expect(response.content).to.equal('Hello! How can I help you today?');
         });
 
         it('should successfully chat with Anthropic service', async () => {
@@ -134,7 +134,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await anthropicLLM.chat(conversationHistory);
             
-            expect(response).to.equal('Hello! I am Claude, an AI assistant created by Anthropic. How can I help you today?');
+            expect(response.content).to.equal('Hello! I am Claude, an AI assistant created by Anthropic. How can I help you today?');
             sinon.assert.calledWith(
                 mockFetch,
                 'https://api.anthropic.com/v1/messages',
@@ -185,7 +185,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await googleLLM.chat(conversationHistory);
             
-            expect(response).to.equal('Hello! I am Gemini, how can I assist you today?');
+            expect(response.content).to.equal('Hello! I am Gemini, how can I assist you today?');
             sinon.assert.calledWith(
                 mockFetch,
                 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
@@ -222,7 +222,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await ollamaLLM.chat(conversationHistory);
             
-            expect(response).to.equal('Hello! I am Llama, how can I help you today?');
+            expect(response.content).to.equal('Hello! I am Llama, how can I help you today?');
             sinon.assert.calledWith(
                 mockFetch,
                 'http://localhost:11434/api/generate',
@@ -298,17 +298,16 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await llm.chat(conversationHistory, { tools });
             
-            expect(response).to.deep.equal({
-                content: null,
-                toolCalls: [{
-                    id: 'call_123',
-                    type: 'function',
-                    function: {
-                        name: 'get_weather',
-                        arguments: '{"location": "New York"}'
-                    }
-                }]
-            });
+            expect(response).to.have.property('metadata');
+            expect(response.content).to.equal(null);
+            expect(response.toolCalls).to.deep.equal([{
+                id: 'call_123',
+                type: 'function',
+                function: {
+                    name: 'get_weather',
+                    arguments: '{"location": "New York"}'
+                }
+            }]);
         });
 
         it('should convert tool schema for Anthropic', async () => {
@@ -363,7 +362,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await anthropicLLM.chat(conversationHistory, { tools });
             
-            expect(response).to.equal('I can help you get the weather information for New York.');
+            expect(response.content).to.equal('I can help you get the weather information for New York.');
             
             // Verify that the request body contains the converted tool schema
             const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
@@ -442,7 +441,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await llm.chat(conversationHistory);
             
-            expect(response).to.equal('Hello from Anthropic fallback!');
+            expect(response.content).to.equal('Hello from Anthropic fallback!');
             sinon.assert.calledTwice(mockFetch);
             
             // Verify first call was to OpenAI
@@ -520,7 +519,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await llm.chat(conversationHistory, customOptions);
             
-            expect(response).to.equal('Response with custom parameters');
+            expect(response.content).to.equal('Response with custom parameters');
             
             const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
             expect(requestBody.temperature).to.equal(1.0);
@@ -564,7 +563,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await llm.chat(conversationHistory, reasoningOptions);
             
-            expect(response).to.equal('Reasoning model response');
+            expect(response.content).to.equal('Reasoning model response');
             
             const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
             expect(requestBody.max_completion_tokens).to.equal(8000);
@@ -607,7 +606,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await llm.chat(conversationHistory, overrideOptions);
             
-            expect(response).to.equal('Response from overridden service');
+            expect(response.content).to.equal('Response from overridden service');
             sinon.assert.calledWith(
                 mockFetch,
                 'https://api.anthropic.com/v1/messages',
@@ -657,11 +656,11 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             // First request should succeed
             const response1 = await rateLimitedLLM.chat(conversationHistory);
-            expect(response1).to.equal('Response 1');
+            expect(response1.content).to.equal('Response 1');
 
             // Second request should also succeed but might be rate limited
             const response2 = await rateLimitedLLM.chat(conversationHistory);
-            expect(response2).to.equal('Response 1');
+            expect(response2.content).to.equal('Response 1');
         });
 
         it('should surface oversized token request errors before making network call', async () => {
@@ -746,7 +745,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
                 }
             );
 
-            expect(response).to.deep.equal({ answer: '42' });
+            expect(response.content).to.deep.equal({ answer: '42' });
             
             const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
             expect(requestBody.response_format.type).to.equal('json_schema');
@@ -772,7 +771,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
                 { responseFormat: 'json' }
             );
 
-            expect(response).to.deep.equal({ status: 'ok' });
+            expect(response.content).to.deep.equal({ status: 'ok' });
         });
 
         it('failure: invalid JSON surfaces JSON_PARSE_ERROR and logs debug output', async () => {
@@ -886,7 +885,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await anthropicLLM.chat(conversationHistory);
             
-            expect(response).to.equal('Hello, I understand my role as a helpful assistant.');
+            expect(response.content).to.equal('Hello, I understand my role as a helpful assistant.');
             
             const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
             expect(requestBody.system).to.equal('You are a helpful assistant specialized in programming.');
@@ -920,7 +919,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await llm.chat([]);
             
-            expect(response).to.equal('How can I help you?');
+            expect(response.content).to.equal('How can I help you?');
         });
     });
 
@@ -996,7 +995,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await llm.chat(conversationHistory);
             
-            expect(response).to.equal('Hello from backup service!');
+            expect(response.content).to.equal('Hello from backup service!');
             sinon.assert.calledTwice(mockFetch);
         });
     }).timeout(35000);
@@ -1015,7 +1014,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
 
             const response = await llm.chat(conversationHistory);
             
-            expect(response).to.be.null; // Should handle gracefully
+            expect(response.content).to.be.null; // Should handle gracefully
         });
 
         it('should handle network errors', async () => {
@@ -1065,7 +1064,7 @@ describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
                 { role: 'user', content: 'Hello in different languages: 你好, здравствуй, 🚀' }
             ];
             const response = await llm.chat(conversationHistory);            
-            expect(response).to.equal('I can handle special characters: 你好, здравствуй, 🚀');
+            expect(response.content).to.equal('I can handle special characters: 你好, здравствуй, 🚀');
         });
     });
 }).timeout(20000);

--- a/test/chat.integration.test.js
+++ b/test/chat.integration.test.js
@@ -1,0 +1,1221 @@
+import { ResilientLLM } from '../dist/index.js';
+import { describe, it, beforeEach, afterEach } from 'mocha';
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+
+// Configure chai to handle promises
+use(chaiAsPromised);
+
+// Preserve global state for mocked-fetch tests cleanup
+const originalEnv = process.env;
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+    process.env = {
+        ...originalEnv,
+        OPENAI_API_KEY: 'test-openai-key',
+        ANTHROPIC_API_KEY: 'test-anthropic-key',
+        GEMINI_API_KEY: 'test-gemini-key',
+        OLLAMA_API_KEY: 'test-ollama-key',
+        OLLAMA_API_URL: 'http://localhost:11434/api/generate'
+    };
+});
+
+afterEach(() => {
+    process.env = originalEnv;
+    globalThis.fetch = originalFetch;
+    sinon.restore();
+});
+
+describe('ResilientLLM Chat Function E2E Tests with mocked fetch', () => {
+    let llm;
+    let mockFetch;
+
+    beforeEach(() => {
+        mockFetch = sinon.stub();
+        global.fetch = mockFetch;
+        llm = new ResilientLLM({
+            aiService: 'openai',
+            model: 'gpt-4o-mini',
+            temperature: 0.7,
+            maxTokens: 2048,//output tokens LLM is allowed to generate
+            timeout: 30000,//timeout for the LLM request
+            rateLimitConfig: { requestsPerMinute: 60, llmTokensPerMinute: 150000 }//rate limit config for the LLM
+        });
+    });
+
+    describe('Basic Chat Functionality', () => {
+        it('should successfully chat with OpenAI service', async () => {
+            const mockResponse = {
+                id: 'chatcmpl-123',
+                object: 'chat.completion',
+                created: 1728933352,
+                model: 'gpt-4o-mini',
+                choices: [{
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: 'Hello! How can I help you today?',
+                        refusal: null
+                    },
+                    logprobs: null,
+                    finish_reason: 'stop'
+                }],
+                usage: {
+                    prompt_tokens: 19,
+                    completion_tokens: 10,
+                    total_tokens: 29
+                }
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello, how are you?' }
+            ];
+
+            const response = await llm.chat(conversationHistory);
+            
+            sinon.assert.calledWith(
+                mockFetch,
+                'https://api.openai.com/v1/chat/completions',
+                sinon.match({
+                    method: 'POST',
+                    headers: sinon.match({
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer test-openai-key'
+                    }),
+                    body: sinon.match(/.*"model":"gpt-4o-mini".*/)
+                })
+            );
+            sinon.assert.calledOnce(mockFetch);
+            expect(response).to.exist;
+            expect(response).to.equal('Hello! How can I help you today?');
+        });
+
+        it('should successfully chat with Anthropic service', async () => {
+            const mockResponse = {
+                id: 'msg_123',
+                type: 'message',
+                role: 'assistant',
+                content: [{
+                    type: 'text',
+                    text: 'Hello! I am Claude, an AI assistant created by Anthropic. How can I help you today?'
+                }],
+                model: 'claude-haiku-4-5-20251001',
+                stop_reason: 'end_turn',
+                stop_sequence: null,
+                usage: {
+                    input_tokens: 12,
+                    output_tokens: 25
+                }
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const anthropicLLM = new ResilientLLM({
+                aiService: 'anthropic',
+                model: 'claude-haiku-4-5-20251001'
+            });
+
+            const conversationHistory = [
+                { role: 'system', content: 'You are a helpful assistant.' },
+                { role: 'user', content: 'Hello, how are you?' }
+            ];
+
+            const response = await anthropicLLM.chat(conversationHistory);
+            
+            expect(response).to.equal('Hello! I am Claude, an AI assistant created by Anthropic. How can I help you today?');
+            sinon.assert.calledWith(
+                mockFetch,
+                'https://api.anthropic.com/v1/messages',
+                sinon.match({
+                    method: 'POST',
+                    headers: sinon.match({
+                        'Content-Type': 'application/json',
+                        'x-api-key': 'test-anthropic-key',
+                        'anthropic-version': '2023-06-01'
+                    }),
+                    body: sinon.match(/.*"system":"You are a helpful assistant.".+/)
+                })
+            );
+        });
+
+        it('should successfully chat with Google service', async () => {
+            const mockResponse = {
+                id: 'chatcmpl-123',
+                object: 'chat.completion',
+                created: 1728933352,
+                model: 'gemini-2.0-flash',
+                choices: [{
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: 'Hello! I am Gemini, how can I assist you today?',
+                        refusal: null
+                    },
+                    logprobs: null,
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const googleLLM = new ResilientLLM({
+                aiService: 'google',
+                model: 'gemini-2.0-flash'
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello, how are you?' }
+            ];
+
+            const response = await googleLLM.chat(conversationHistory);
+            
+            expect(response).to.equal('Hello! I am Gemini, how can I assist you today?');
+            sinon.assert.calledWith(
+                mockFetch,
+                'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
+                sinon.match({
+                    method: 'POST',
+                    headers: sinon.match({
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer test-gemini-key'
+                    })
+                })
+            );
+        });
+
+        it('should successfully chat with Ollama service', async () => {
+            const mockResponse = {
+                response: 'Hello! I am Llama, how can I help you today?',
+                done: true
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const ollamaLLM = new ResilientLLM({
+                aiService: 'ollama',
+                model: 'openai'
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello, how are you?' }
+            ];
+
+            const response = await ollamaLLM.chat(conversationHistory);
+            
+            expect(response).to.equal('Hello! I am Llama, how can I help you today?');
+            sinon.assert.calledWith(
+                mockFetch,
+                'http://localhost:11434/api/generate',
+                sinon.match({
+                    method: 'POST',
+                    headers: sinon.match({
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer test-ollama-key'
+                    })
+                })
+            );
+        });
+    });
+
+    describe('Tool Calling Support', () => {
+        it('should handle tool calls with OpenAI', async () => {
+            const mockResponse = {
+                id: 'chatcmpl-123',
+                object: 'chat.completion',
+                created: 1728933352,
+                model: 'gpt-4o-mini',
+                choices: [{
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: null,
+                        tool_calls: [{
+                            id: 'call_123',
+                            type: 'function',
+                            function: {
+                                name: 'get_weather',
+                                arguments: '{"location": "New York"}'
+                            }
+                        }]
+                    },
+                    logprobs: null,
+                    finish_reason: 'tool_calls'
+                }],
+                usage: {
+                    prompt_tokens: 50,
+                    completion_tokens: 20,
+                    total_tokens: 70
+                }
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'What is the weather like in New York?' }
+            ];
+
+            const tools = [{
+                type: 'function',
+                function: {
+                    name: 'get_weather',
+                    description: 'Get the current weather in a given location',
+                    parameters: {
+                        type: 'object',
+                        properties: {
+                            location: {
+                                type: 'string',
+                                description: 'The city and state, e.g. San Francisco, CA'
+                            }
+                        },
+                        required: ['location']
+                    }
+                }
+            }];
+
+            const response = await llm.chat(conversationHistory, { tools });
+            
+            expect(response).to.deep.equal({
+                content: null,
+                toolCalls: [{
+                    id: 'call_123',
+                    type: 'function',
+                    function: {
+                        name: 'get_weather',
+                        arguments: '{"location": "New York"}'
+                    }
+                }]
+            });
+        });
+
+        it('should convert tool schema for Anthropic', async () => {
+            const mockResponse = {
+                id: 'msg_123',
+                type: 'message',
+                role: 'assistant',
+                content: [{
+                    type: 'text',
+                    text: 'I can help you get the weather information for New York.'
+                }],
+                model: 'claude-haiku-4-5-20251001',
+                stop_reason: 'end_turn',
+                usage: {
+                    input_tokens: 50,
+                    output_tokens: 15
+                }
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const anthropicLLM = new ResilientLLM({
+                aiService: 'anthropic',
+                model: 'claude-haiku-4-5-20251001'
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'What is the weather like in New York?' }
+            ];
+
+            const tools = [{
+                type: 'function',
+                function: {
+                    name: 'get_weather',
+                    description: 'Get the current weather in a given location',
+                    parameters: {
+                        type: 'object',
+                        properties: {
+                            location: {
+                                type: 'string',
+                                description: 'The city and state, e.g. San Francisco, CA'
+                            }
+                        },
+                        required: ['location']
+                    }
+                }
+            }];
+
+            const response = await anthropicLLM.chat(conversationHistory, { tools });
+            
+            expect(response).to.equal('I can help you get the weather information for New York.');
+            
+            // Verify that the request body contains the converted tool schema
+            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
+            expect(requestBody.tools[0].function.input_schema).to.exist;
+            expect(requestBody.tools[0].function.parameters).to.be.undefined;
+        });
+    });
+
+    describe('Error Handling', () => {
+        it('should handle 401 authentication errors', async () => {
+            const mockErrorResponse = {
+                error: {
+                    message: 'Invalid API key',
+                    type: 'invalid_request_error',
+                    param: null,
+                    code: 'invalid_api_key'
+                }
+            };
+
+            mockFetch.resolves({
+                ok: false,
+                status: 401,
+                json: async () => mockErrorResponse
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+
+            await expect(llm.chat(conversationHistory)).to.be.rejectedWith('Invalid API key');
+        });
+
+        it('should handle 429 rate limit errors and retry with alternate service', async () => {
+            const mockRateLimitResponse = {
+                error: {
+                    message: 'Rate limit exceeded',
+                    type: 'rate_limit_error',
+                    param: null,
+                    code: 'rate_limit_exceeded'
+                }
+            };
+
+            const mockAnthropicResponse = {
+                id: 'msg_123',
+                type: 'message',
+                role: 'assistant',
+                content: [{
+                    type: 'text',
+                    text: 'Hello from Anthropic fallback!'
+                }],
+                model: 'claude-haiku-4-5-20251001',
+                stop_reason: 'end_turn',
+                usage: {
+                    input_tokens: 12,
+                    output_tokens: 8
+                }
+            };
+
+            // First call to OpenAI fails with rate limit
+            mockFetch.onFirstCall().resolves({
+                ok: false,
+                status: 429,
+                json: async () => mockRateLimitResponse
+            });
+
+            // Second call to Anthropic succeeds
+            mockFetch.onSecondCall().resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockAnthropicResponse
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+
+            const response = await llm.chat(conversationHistory);
+            
+            expect(response).to.equal('Hello from Anthropic fallback!');
+            sinon.assert.calledTwice(mockFetch);
+            
+            // Verify first call was to OpenAI
+            expect(mockFetch.getCall(0).args[0]).to.equal('https://api.openai.com/v1/chat/completions');
+            
+            // Verify second call was to Anthropic
+            expect(mockFetch.getCall(1).args[0]).to.equal('https://api.anthropic.com/v1/messages');
+        });
+
+        it('should handle token limit exceeded', async () => {
+            const longText = 'a'.repeat(404040); // Very long text to exceed token limit
+            const conversationHistory = [
+                { role: 'user', content: longText }
+            ];
+
+            await expect(llm.chat(conversationHistory)).to.be.rejectedWith('Input tokens exceed the maximum limit');
+        });
+
+        it('should handle invalid AI service', async () => {
+            const invalidLLM = new ResilientLLM({
+                aiService: 'invalid-service'
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+
+            await expect(invalidLLM.chat(conversationHistory)).to.be.rejectedWith('Invalid provider specified');
+        });
+
+        it('should handle missing API key', async () => {
+            process.env.OPENAI_API_KEY = '';
+            
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+            await expect(llm.chat(conversationHistory)).to.be.rejected;
+        });
+    });
+
+    describe('LLM Options and Configuration', () => {
+        it('should handle custom temperature and max tokens', async () => {
+            const mockResponse = {
+                id: 'chatcmpl-123',
+                object: 'chat.completion',
+                created: 1728933352,
+                model: 'gpt-4o-mini',
+                choices: [{
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: 'Response with custom parameters',
+                        refusal: null
+                    },
+                    logprobs: null,
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+
+            const customOptions = {
+                temperature: 1.0,
+                maxTokens: 4000,
+                topP: 0.8
+            };
+
+            const response = await llm.chat(conversationHistory, customOptions);
+            
+            expect(response).to.equal('Response with custom parameters');
+            
+            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
+            expect(requestBody.temperature).to.equal(1.0);
+            expect(requestBody.max_tokens).to.equal(4000);
+            expect(requestBody.top_p).to.equal(0.8);
+        });
+
+        it('should handle reasoning models (o1) with different parameters', async () => {
+            const mockResponse = {
+                id: 'chatcmpl-123',
+                object: 'chat.completion',
+                created: 1728933352,
+                model: 'o1-preview',
+                choices: [{
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: 'Reasoning model response',
+                        refusal: null
+                    },
+                    logprobs: null,
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Solve this complex problem' }
+            ];
+
+            const reasoningOptions = {
+                model: 'o1-preview',
+                maxCompletionTokens: 8000,
+                reasoningEffort: 'high'
+            };
+
+            const response = await llm.chat(conversationHistory, reasoningOptions);
+            
+            expect(response).to.equal('Reasoning model response');
+            
+            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
+            expect(requestBody.max_completion_tokens).to.equal(8000);
+            expect(requestBody.reasoning_effort).to.equal('high');
+            expect(requestBody.temperature).to.be.undefined; // Should not be set for reasoning models
+        });
+
+
+        it('should override service and model in options', async () => {
+            const mockResponse = {
+                id: 'msg_123',
+                type: 'message',
+                role: 'assistant',
+                content: [{
+                    type: 'text',
+                    text: 'Response from overridden service'
+                }],
+                model: 'claude-haiku-4-5-20251001',
+                stop_reason: 'end_turn',
+                usage: {
+                    input_tokens: 12,
+                    output_tokens: 8
+                }
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+
+            const overrideOptions = {
+                aiService: 'anthropic',
+                model: 'claude-haiku-4-5-20251001'
+            };
+
+            const response = await llm.chat(conversationHistory, overrideOptions);
+            
+            expect(response).to.equal('Response from overridden service');
+            sinon.assert.calledWith(
+                mockFetch,
+                'https://api.anthropic.com/v1/messages',
+                sinon.match({
+                    method: 'POST',
+                    headers: sinon.match({
+                        'x-api-key': 'test-anthropic-key'
+                    })
+                })
+            );
+        });
+    });
+
+    describe('Rate Limiting and Resilience', () => {
+        it('should handle rate limiting with token bucket', async () => {
+            const rateLimitedLLM = new ResilientLLM({
+                aiService: 'openai',
+                rateLimitConfig: { requestsPerMinute: 1, llmTokensPerMinute: 1000 }
+            });
+
+            const mockResponse = {
+                id: 'chatcmpl-123',
+                object: 'chat.completion',
+                created: 1728933352,
+                model: 'gpt-4o-mini',
+                choices: [{
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: 'Response 1',
+                        refusal: null
+                    },
+                    logprobs: null,
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+
+            // First request should succeed
+            const response1 = await rateLimitedLLM.chat(conversationHistory);
+            expect(response1).to.equal('Response 1');
+
+            // Second request should also succeed but might be rate limited
+            const response2 = await rateLimitedLLM.chat(conversationHistory);
+            expect(response2).to.equal('Response 1');
+        });
+
+        it('should surface oversized token request errors before making network call', async () => {
+            const oversizedTokenLLM = new ResilientLLM({
+                aiService: 'openai',
+                model: 'gpt-4o-mini',
+                maxInputTokens: 50000,
+                rateLimitConfig: { requestsPerMinute: 60, llmTokensPerMinute: 1000 }
+            });
+
+            sinon.stub(ResilientLLM, 'estimateTokens').returns(1001);
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+
+            await expect(
+                oversizedTokenLLM.chat(conversationHistory)
+            ).to.be.rejectedWith('Cannot remove more tokens than the bucket capacity');
+
+            sinon.assert.notCalled(mockFetch);
+        });
+
+        it('should handle timeout scenarios', async () => {
+            const timeoutLLM = new ResilientLLM({
+                aiService: 'openai',
+                timeout: 1000 // 1 second timeout
+            });
+
+            // Mock a delayed response
+            mockFetch.callsFake(() => 
+                new Promise((resolve) => {
+                    setTimeout(() => resolve({
+                        ok: true,
+                        status: 200,
+                        json: async () => ({ choices: [{ message: { content: 'Late response' } }] })
+                    }), 2000); // 2 second delay
+                })
+            );
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+            await expect(timeoutLLM.chat(conversationHistory)).to.be.rejectedWith('Operation timed out');
+        });
+    });
+
+
+    describe('Structured output test with mocked fetch', () => {
+        it('happy path: should normalize schema-based response into object', async () => {
+            const mockResponse = {
+                id: 'chatcmpl-123',
+                object: 'chat.completion',
+                created: 1728933352,
+                model: 'gpt-4o-mini',
+                choices: [{
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: '{"answer": "42"}',
+                        refusal: null
+                    },
+                    logprobs: null,
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'What is the answer to life, the universe, and everything? Respond in JSON format.' }
+            ];
+
+            const jsonSchemaOptions = {
+                responseFormat: {
+                    type: 'json_schema',
+                    json_schema: {
+                        name: 'answer_payload',
+                        schema: {
+                            type: 'object',
+                            properties: {
+                                answer: { type: 'string' }
+                            },
+                            required: ['answer']
+                        }
+                    }
+                }
+            };
+
+            const response = await llm.chat(conversationHistory, jsonSchemaOptions);
+
+            expect(response).to.deep.equal({ answer: '42' });
+            
+            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
+            expect(requestBody.response_format.type).to.equal('json_schema');
+            expect(requestBody.response_format.json_schema.schema.required).to.deep.equal(['answer']);
+        });
+
+        it('should not synthesize Anthropic output_config when no schema is provided', async () => {
+            const mockResponse = {
+                id: 'msg_123',
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'text', text: '{"answer":"42"}' }],
+                stop_reason: 'end_turn',
+                usage: { input_tokens: 10, output_tokens: 5 }
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const anthropicLLM = new ResilientLLM({
+                aiService: 'anthropic',
+                model: 'claude-haiku-4-5-20251001'
+            });
+
+            await anthropicLLM.chat(
+                [{ role: 'user', content: 'Return JSON object with answer.' }],
+                { responseFormat: 'json' }
+            );
+
+            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
+            expect(requestBody.output_config).to.equal(undefined);
+            expect(requestBody.response_format).to.equal(undefined);
+        });
+
+        it('should pass through explicit output_config without modifying it', async () => {
+            const mockResponse = {
+                id: 'msg_123',
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'text', text: '{"answer":"42"}' }],
+                stop_reason: 'end_turn',
+                usage: { input_tokens: 10, output_tokens: 5 }
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const anthropicLLM = new ResilientLLM({
+                aiService: 'anthropic',
+                model: 'claude-haiku-4-5-20251001'
+            });
+            const output_config = { format: { type: 'json_schema' } };
+
+            const response = await anthropicLLM.chat(
+                [{ role: 'user', content: 'Return JSON object with answer.' }],
+                { output_config }
+            );
+
+            expect(response).to.deep.equal({ answer: '42' });
+            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
+            expect(requestBody.output_config).to.deep.equal(output_config);
+            expect(requestBody.response_format).to.equal(undefined);
+        });
+
+        it('should pass through explicit response_format without modifying it', async () => {
+            const mockResponse = {
+                choices: [{
+                    message: {
+                        role: 'assistant',
+                        content: '{"answer":"42"}',
+                    },
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const response_format = { type: 'json_schema', json_schema: { name: 'answer_payload', schema: { type: 'object' } } };
+            const response = await llm.chat(
+                [{ role: 'user', content: 'Return JSON object with answer.' }],
+                { response_format }
+            );
+
+            expect(response).to.deep.equal({ answer: '42' });
+            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
+            expect(requestBody.response_format).to.deep.equal(response_format);
+        });
+
+        it('should fail fast when both responseFormat and response_format are provided', async () => {
+            await expect(
+                llm.chat(
+                    [{ role: 'user', content: 'Return JSON only.' }],
+                    {
+                        responseFormat: { type: 'json_object' },
+                        response_format: { type: 'json_object' }
+                    }
+                )
+            ).to.be.rejectedWith('Provide either "responseFormat" or "response_format", not both.');
+
+            sinon.assert.notCalled(mockFetch);
+        });
+
+        it('should parse markdown-fenced JSON in structured output mode', async () => {
+            const mockResponse = {
+                choices: [{
+                    message: {
+                        role: 'assistant',
+                        content: '```json\n{"answer":"42"}\n```',
+                    },
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const response = await llm.chat(
+                [{ role: 'user', content: 'Return JSON only.' }],
+                { responseFormat: 'json' }
+            );
+
+            expect(response).to.deep.equal({ answer: '42' });
+        });
+
+        it('edge case: should fail clearly when JSON parsing fails', async () => {
+            const mockResponse = {
+                choices: [{
+                    message: {
+                        role: 'assistant',
+                        content: '{"answer": "42"',
+                    },
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            await expect(
+                llm.chat(
+                    [{ role: 'user', content: 'Return JSON only.' }],
+                    { responseFormat: 'json' }
+                )
+            ).to.be.rejectedWith('JSON parse failed for structured response');
+        });
+
+        it('should return raw content when parseStructuredOutput is false', async () => {
+            const mockResponse = {
+                choices: [{
+                    message: {
+                        role: 'assistant',
+                        content: '{"answer":"42"}',
+                    },
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const response = await llm.chat(
+                [{ role: 'user', content: 'Return JSON only.' }],
+                {
+                    responseFormat: { type: 'json_object' },
+                    parseStructuredOutput: false
+                }
+            );
+
+            expect(response).to.equal('{"answer":"42"}');
+        });
+
+        it('edge case: should return schema mismatch details for missing fields and wrong type', async () => {
+            const mockResponse = {
+                choices: [{
+                    message: {
+                        role: 'assistant',
+                        content: '{"title":123}',
+                    },
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            try {
+                await llm.chat(
+                    [{ role: 'user', content: 'Return schema-constrained JSON.' }],
+                    {
+                        responseFormat: {
+                            type: 'json_schema',
+                            json_schema: {
+                                name: 'card',
+                                schema: {
+                                    type: 'object',
+                                    properties: {
+                                        title: { type: 'string' },
+                                        score: { type: 'number' }
+                                    },
+                                    required: ['title', 'score']
+                                }
+                            }
+                        }
+                    }
+                );
+                throw new Error('Expected schema mismatch error');
+            } catch (error) {
+                expect(error.message).to.include('Schema mismatch');
+                expect(error.code).to.equal('SCHEMA_MISMATCH');
+                expect(error.validation.missingFields).to.deep.equal(['score']);
+                expect(error.validation.typeMismatches).to.deep.equal([
+                    { field: 'title', expected: 'string', actual: 'integer' }
+                ]);
+                expect(error.rawResponse).to.equal('{"title":123}');
+            }
+        });
+    });
+
+    describe('Conversation History Formatting', () => {
+        it('should format system messages correctly for Anthropic', async () => {
+            const mockResponse = {
+                id: 'msg_123',
+                type: 'message',
+                role: 'assistant',
+                content: [{
+                    type: 'text',
+                    text: 'Hello, I understand my role as a helpful assistant.'
+                }],
+                model: 'claude-haiku-4-5-20251001',
+                stop_reason: 'end_turn',
+                usage: {
+                    input_tokens: 30,
+                    output_tokens: 12
+                }
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const anthropicLLM = new ResilientLLM({
+                aiService: 'anthropic',
+                model: 'claude-haiku-4-5-20251001'
+            });
+
+            const conversationHistory = [
+                { role: 'system', content: 'You are a helpful assistant specialized in programming.' },
+                { role: 'user', content: 'Hello' },
+                { role: 'assistant', content: 'Hi there! How can I help you with programming?' },
+                { role: 'user', content: 'What is JavaScript?' }
+            ];
+
+            const response = await anthropicLLM.chat(conversationHistory);
+            
+            expect(response).to.equal('Hello, I understand my role as a helpful assistant.');
+            
+            const requestBody = JSON.parse(mockFetch.getCall(0).args[1].body);
+            expect(requestBody.system).to.equal('You are a helpful assistant specialized in programming.');
+            expect(requestBody.messages).to.have.length(3); // System message should be removed from messages array
+            expect(requestBody.messages[0].role).to.equal('user');
+        });
+
+        it('should handle empty conversation history', async () => {
+            const mockResponse = {
+                id: 'chatcmpl-123',
+                object: 'chat.completion',
+                created: 1728933352,
+                model: 'gpt-4o-mini',
+                choices: [{
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: 'How can I help you?',
+                        refusal: null
+                    },
+                    logprobs: null,
+                    finish_reason: 'stop'
+                }]
+            };
+
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+
+            const response = await llm.chat([]);
+            
+            expect(response).to.equal('How can I help you?');
+        });
+    });
+
+    describe('Fallback and Retry Logic', () => {
+        it('should exhaust all services before failing', async () => {
+            const mockErrorResponse = {
+                error: {
+                    message: 'Service unavailable',
+                    type: 'service_unavailable',
+                    code: 'service_unavailable'
+                }
+            };
+
+            // Mock all services to return 429 (rate limited)
+            mockFetch.resolves({
+                ok: false,
+                status: 429,
+                json: async () => mockErrorResponse
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+
+            await expect(llm.chat(conversationHistory)).to.be.rejectedWith('No alternative model found');
+            
+            // Should try multiple services (OpenAI, then Anthropic, then Google, then Ollama)
+            sinon.assert.callCount(mockFetch, 4);
+        }).timeout(35000);
+
+        it('should succeed with second service when first fails', async () => {
+            const mockErrorResponse = {
+                error: {
+                    message: 'Service unavailable',
+                    type: 'service_unavailable',
+                    code: 'service_unavailable'
+                }
+            };
+
+            const mockSuccessResponse = {
+                id: 'msg_123',
+                type: 'message',
+                role: 'assistant',
+                content: [{
+                    type: 'text',
+                    text: 'Hello from backup service!'
+                }],
+                model: 'claude-haiku-4-5-20251001',
+                stop_reason: 'end_turn',
+                usage: {
+                    input_tokens: 12,
+                    output_tokens: 8
+                }
+            };
+
+            // First call fails
+            mockFetch.onFirstCall().resolves({
+                ok: false,
+                status: 429,
+                json: async () => mockErrorResponse
+            });
+
+            // Second call succeeds
+            mockFetch.onSecondCall().resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockSuccessResponse
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+
+            const response = await llm.chat(conversationHistory);
+            
+            expect(response).to.equal('Hello from backup service!');
+            sinon.assert.calledTwice(mockFetch);
+        });
+    }).timeout(35000);
+
+    describe('Edge Cases and Special Scenarios', () => {
+        it('should handle malformed API responses gracefully', async () => {
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => ({ malformed: 'response' })
+            });
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+
+            const response = await llm.chat(conversationHistory);
+            
+            expect(response).to.be.null; // Should handle gracefully
+        });
+
+        it('should handle network errors', async () => {
+            mockFetch.rejects(new Error('Network error'));
+
+            const conversationHistory = [
+                { role: 'user', content: 'Hello' }
+            ];
+
+            await expect(llm.chat(conversationHistory)).to.be.rejectedWith('Network error');
+        });
+
+        it('should handle very long conversation histories', async () => {
+            const longConversationHistory = [];
+            for (let i = 0; i < 10000; i++) {
+                longConversationHistory.push({
+                    role: i % 2 === 0 ? 'user' : 'assistant',
+                    content: `Message ${i}: This is a test message to create a long conversation history.`
+                });
+            }
+            await expect(llm.chat(longConversationHistory)).to.be.rejectedWith('Input tokens exceed the maximum limit');
+        });
+
+        it('should handle special characters in conversation', async () => {
+            const mockResponse = {
+                id: 'chatcmpl-123',
+                object: 'chat.completion',
+                created: 1728933352,
+                model: 'gpt-4o-mini',
+                choices: [{
+                    index: 0,
+                    message: {
+                        role: 'assistant',
+                        content: 'I can handle special characters: 你好, здравствуй, 🚀',
+                        refusal: null
+                    },
+                    logprobs: null,
+                    finish_reason: 'stop'
+                }]
+            };
+            mockFetch.resolves({
+                ok: true,
+                status: 200,
+                json: async () => mockResponse
+            });
+            const conversationHistory = [
+                { role: 'user', content: 'Hello in different languages: 你好, здравствуй, 🚀' }
+            ];
+            const response = await llm.chat(conversationHistory);            
+            expect(response).to.equal('I can handle special characters: 你好, здравствуй, 🚀');
+        });
+    });
+}).timeout(20000);

--- a/test/resilient-llm-metadata.test.js
+++ b/test/resilient-llm-metadata.test.js
@@ -49,7 +49,7 @@ describe('ResilientLLM Metadata (Phase 1)', () => {
         sinon.restore();
     });
 
-    it('happy path: returnOperationMetadata=true returns { content, metadata } with populated fields', async () => {
+    it('happy path: returns { content, metadata } with populated fields', async () => {
         global.fetch = mockFetchOk('Test response');
 
         const llm = new ResilientLLM({
@@ -57,7 +57,6 @@ describe('ResilientLLM Metadata (Phase 1)', () => {
             model: 'gpt-4o-mini',
             maxTokens: 1024,
             temperature: 0.5,
-            returnOperationMetadata: true,
         });
 
         const result = await llm.chat([{ role: 'user', content: 'Hi' }]);
@@ -70,6 +69,7 @@ describe('ResilientLLM Metadata (Phase 1)', () => {
         expect(metadata.requestId).to.be.a('string').and.not.be.empty;
         expect(metadata.operationId).to.be.a('string').and.not.be.empty;
         expect(metadata.startTime).to.be.a('number');
+        expect(metadata.finishReason).to.equal('stop');
 
         expect(metadata.config.aiService).to.equal('openai');
         expect(metadata.config.model).to.equal('gpt-4o-mini');
@@ -95,7 +95,7 @@ describe('ResilientLLM Metadata (Phase 1)', () => {
         expect(metadata.service.final).to.equal('openai');
     }).timeout(15000);
 
-    it('edge case: default (no flag) returns raw content string, not an object', async () => {
+    it('edge case: default (no flag) returns envelope with metadata', async () => {
         global.fetch = mockFetchOk('Plain response');
 
         const llm = new ResilientLLM({
@@ -106,28 +106,8 @@ describe('ResilientLLM Metadata (Phase 1)', () => {
 
         const result = await llm.chat([{ role: 'user', content: 'Hi' }]);
 
-        expect(result).to.equal('Plain response');
-    }).timeout(15000);
-
-    it('edge case: per-call returnOperationMetadata overrides constructor false', async () => {
-        global.fetch = mockFetchOk('Override response');
-
-        const llm = new ResilientLLM({
-            aiService: 'openai',
-            model: 'gpt-4o-mini',
-            maxTokens: 1024,
-            returnOperationMetadata: false,
-        });
-
-        const result = await llm.chat(
-            [{ role: 'user', content: 'Hi' }],
-            { returnOperationMetadata: true }
-        );
-
-        expect(result).to.be.an('object');
-        expect(result).to.have.property('content', 'Override response');
+        expect(result).to.have.property('content', 'Plain response');
         expect(result).to.have.property('metadata');
-        expect(result.metadata.requestId).to.be.a('string');
-        expect(result.metadata.timing.totalTimeMs).to.be.a('number');
     }).timeout(15000);
+
 });

--- a/test/resilient-llm.unit.test.js
+++ b/test/resilient-llm.unit.test.js
@@ -59,7 +59,7 @@ describe('ResilientLLM Unit Tests', () => {
             const result = await resilientLLM.chat(conversationHistory);
 
             // Assert
-            expect(result).to.equal(mockAnthropicResponse.content[0].text);
+            expect(result.content).to.equal(mockAnthropicResponse.content[0].text);
             expect(mockFetch.callCount).to.be.equal(1);
         });
     });
@@ -91,13 +91,29 @@ describe('ResilientLLM Unit Tests', () => {
             });
             
             // Mock the retry method to return success
-            sinon.stub(resilientLLM, 'retryChatWithAlternateService').resolves(mockAnthropicResponse.content[0].text);
+            sinon.stub(resilientLLM, 'retryChatWithAlternateService').resolves({
+                content: mockAnthropicResponse.content[0].text,
+                metadata: {
+                    requestId: 'test-request',
+                    operationId: 'test-operation',
+                    startTime: Date.now(),
+                    config: { aiService: resilientLLM.aiService, model: resilientLLM.model },
+                    events: [],
+                    timing: { totalTimeMs: 0, rateLimitWaitMs: 0, httpRequestMs: 0 },
+                    retries: [],
+                    rateLimiting: { requestedTokens: 0, totalWaitMs: 0 },
+                    circuitBreaker: {},
+                    http: {},
+                    cache: {},
+                    service: { attempted: [resilientLLM.aiService], final: resilientLLM.aiService },
+                }
+            });
 
             // Act
             const result = await resilientLLM.chat(conversationHistory);
 
             // Assert
-            expect(result).to.equal(mockAnthropicResponse.content[0].text);
+            expect(result.content).to.equal(mockAnthropicResponse.content[0].text);
             expect(resilientLLM.retryChatWithAlternateService.calledOnce).to.be.true;
             expect(mockFetch.callCount).to.be.equal(1);
         });


### PR DESCRIPTION
- [x] Refactor operational metadata (not related to the PR topic)
- [x] Add structured output abstraction for better maintenance
- [x] Add support to automatic schema parsing (default) or parsing on demand (by setting `parseStructuredOutput:false` and then `structuredOutput.parse(content)`) 
- [x] Add support for anthropic json mode support by using the correct param `output_config.format`
- [x] Add alias for `responseFormat` - `outputConfig.format` to support anthropic user mental model
- [x] Smart normalization (when camelCase options are used `outputConfig`/`responseFormat`) to support whichever options lib consumer finds intuitive
- [x] No normalization, pass options to API as it is when snake case options are used (`response_format`/`output_config`) to support easy migration and to override normalization behavior
- [x] Refactor test by separate chat integration vs e2e
- [x] Add e2e test cases for structured response
- [x] Refactor chat function and the ChatResponse (breaking change)